### PR TITLE
fix(SubmissionController): update section state when attachment is removed

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
@@ -277,6 +277,7 @@ public class SubmissionController {
         final GrantAttachment attachment = grantAttachmentService.getAttachment(attachmentId);
         attachmentService.deleteAttachment(attachment, applicationId, submissionId, questionId);
         submissionService.deleteQuestionResponse(submissionId, questionId);
+        submissionService.handleSectionReview(submissionId, sectionId, Boolean.FALSE);
 
         final GetNavigationParamsDto nextNav = GetNavigationParamsDto.builder()
                 .responseAccepted(Boolean.TRUE)

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
@@ -756,6 +756,7 @@ class SubmissionControllerTest {
 
         verify(attachmentService).deleteAttachment(attachment, applicationId, SUBMISSION_ID, QUESTION_ID_1);
         verify(submissionService).deleteQuestionResponse(SUBMISSION_ID, QUESTION_ID_1);
+        verify(submissionService).handleSectionReview(SUBMISSION_ID, SECTION_ID_1, Boolean.FALSE);
     }
 
     @Test


### PR DESCRIPTION
Background
When a user uploads a file - the question is marked as “Complete”. If the file is removed and a user selects ‘back’. There is no file uploaded to the file upload question, but the section is still marked as “Complete”.

Fix
Call handleSectionReview method to update section state to "IN PROGRESS"

Testing
Updated existing test to verify method is called

JIRA
Fixes https://technologyprogramme.atlassian.net/browse/GAP-1758