### PR TITLE
Gap 1673/authenticate lambda endpoint

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/exception/UnauthorizedException.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/exception/UnauthorizedException.java
@@ -1,5 +1,9 @@
 package gov.cabinetoffice.gap.applybackend.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
 public class UnauthorizedException extends RuntimeException {
 
     public UnauthorizedException() {

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/exception/UnauthorizedException.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/exception/UnauthorizedException.java
@@ -1,0 +1,20 @@
+package gov.cabinetoffice.gap.applybackend.exception;
+
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException() {
+    }
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+
+    public UnauthorizedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UnauthorizedException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SecretAuthService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SecretAuthService.java
@@ -1,6 +1,6 @@
 package gov.cabinetoffice.gap.applybackend.service;
 
-import com.amazonaws.services.cognitoidp.model.UnauthorizedException;
+import gov.cabinetoffice.gap.applybackend.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SecretAuthService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SecretAuthService.java
@@ -1,0 +1,29 @@
+package gov.cabinetoffice.gap.applybackend.service;
+
+import com.amazonaws.services.cognitoidp.model.UnauthorizedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class SecretAuthService {
+
+    @Value("${lambda.secret}")
+    private String lambdaSecret;
+
+    /**
+     * Intended to authenticate requests coming from lambdas, which shouldn't pass through
+     * the JWT auth process. TODO I think this could be converted into an annotation for
+     * lambda controller methods
+     * @param authHeader value taken from Authorization header
+     */
+    public void authenticateSecret(String authHeader) {
+        if (!Objects.equals(lambdaSecret, authHeader)) {
+            throw new UnauthorizedException("Secret key does not match");
+        }
+    }
+
+}

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
@@ -201,11 +201,8 @@ public class SubmissionController {
                                                    @PathVariable final String questionId,
                                                    @RequestBody final UpdateAttachmentDto updateDetails,
                                                    @RequestHeader(HttpHeaders.AUTHORIZATION) final String authHeader) {
-        try {
-            secretAuthService.authenticateSecret(authHeader);
-        } catch(UnauthorizedException e){
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
+
+        secretAuthService.authenticateSecret(authHeader);
 
         Submission submission = submissionService.getSubmissionFromDatabaseBySubmissionId(submissionId);
         GrantAttachment attachment = grantAttachmentService.getAttachmentBySubmissionAndQuestion(submission, questionId);

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
@@ -5,10 +5,7 @@ import gov.cabinetoffice.gap.applybackend.constants.APIConstants;
 import gov.cabinetoffice.gap.applybackend.dto.api.*;
 import gov.cabinetoffice.gap.applybackend.enums.GrantAttachmentStatus;
 import gov.cabinetoffice.gap.applybackend.enums.SubmissionSectionStatus;
-import gov.cabinetoffice.gap.applybackend.exception.AttachmentException;
-import gov.cabinetoffice.gap.applybackend.exception.GrantApplicationNotPublishedException;
-import gov.cabinetoffice.gap.applybackend.exception.NotFoundException;
-import gov.cabinetoffice.gap.applybackend.exception.SubmissionAlreadyCreatedException;
+import gov.cabinetoffice.gap.applybackend.exception.*;
 import gov.cabinetoffice.gap.applybackend.model.*;
 import gov.cabinetoffice.gap.applybackend.service.*;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +13,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -203,7 +201,11 @@ public class SubmissionController {
                                                    @PathVariable final String questionId,
                                                    @RequestBody final UpdateAttachmentDto updateDetails,
                                                    @RequestHeader(HttpHeaders.AUTHORIZATION) final String authHeader) {
-        secretAuthService.authenticateSecret(authHeader);
+        try {
+            secretAuthService.authenticateSecret(authHeader);
+        } catch(UnauthorizedException e){
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
 
         Submission submission = submissionService.getSubmissionFromDatabaseBySubmissionId(submissionId);
         GrantAttachment attachment = grantAttachmentService.getAttachmentBySubmissionAndQuestion(submission, questionId);

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -35,6 +36,8 @@ public class SubmissionController {
     private final GrantApplicantService grantApplicantService;
     private final GrantAttachmentService grantAttachmentService;
     private final GrantApplicationService grantApplicationService;
+
+    private final SecretAuthService secretAuthService;
     private final AttachmentService attachmentService;
     private final Logger logger = LoggerFactory.getLogger(SubmissionController.class);
     private final Clock clock;
@@ -198,7 +201,10 @@ public class SubmissionController {
     @PutMapping("/{submissionId}/question/{questionId}/attachment/scanresult")
     public ResponseEntity<String> updateAttachment(@PathVariable final UUID submissionId,
                                                    @PathVariable final String questionId,
-                                                   @RequestBody final UpdateAttachmentDto updateDetails) {
+                                                   @RequestBody final UpdateAttachmentDto updateDetails,
+                                                   @RequestHeader(HttpHeaders.AUTHORIZATION) final String authHeader) {
+        secretAuthService.authenticateSecret(authHeader);
+
         Submission submission = submissionService.getSubmissionFromDatabaseBySubmissionId(submissionId);
         GrantAttachment attachment = grantAttachmentService.getAttachmentBySubmissionAndQuestion(submission, questionId);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,3 +34,5 @@ gov-notify.submissionConfirmationTemplate=a-notify-template-id
 # environment specific props
 frontEndUri=a-front-end-url
 environmentName=an-environment-name
+
+lambda.secret=lambdaSecretKey

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/SecretAuthServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/SecretAuthServiceTest.java
@@ -1,0 +1,37 @@
+package gov.cabinetoffice.gap.applybackend.service;
+
+import com.amazonaws.services.cognitoidp.model.UnauthorizedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@SpringJUnitConfig
+class SecretAuthServiceTest {
+
+    @InjectMocks
+    private SecretAuthService secretAuthService;
+
+    private final String correctSecretKey = "topSecretKey";
+
+    @BeforeEach
+    void beforeEach() {
+        ReflectionTestUtils.setField(secretAuthService, "lambdaSecret", correctSecretKey);
+    }
+
+    @Test
+    void authenticateSecret_HappyPath() {
+        assertThatNoException().isThrownBy(() -> secretAuthService.authenticateSecret(correctSecretKey));
+    }
+
+    @Test
+    void authenticateSecret_UnhappyPath() {
+        assertThatThrownBy(() -> secretAuthService.authenticateSecret("wrongKey"))
+                .isInstanceOf(UnauthorizedException.class).hasMessage("Secret key does not match");
+    }
+
+}

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/SecretAuthServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/SecretAuthServiceTest.java
@@ -1,6 +1,6 @@
 package gov.cabinetoffice.gap.applybackend.service;
 
-import com.amazonaws.services.cognitoidp.model.UnauthorizedException;
+import gov.cabinetoffice.gap.applybackend.exception.UnauthorizedException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
@@ -1,6 +1,5 @@
 package gov.cabinetoffice.gap.applybackend.web;
 
-import com.amazonaws.services.cognitoidp.model.UnauthorizedException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import gov.cabinetoffice.gap.applybackend.constants.APIConstants;
 import gov.cabinetoffice.gap.applybackend.dto.api.*;
@@ -8,10 +7,7 @@ import gov.cabinetoffice.gap.applybackend.enums.GrantAttachmentStatus;
 import gov.cabinetoffice.gap.applybackend.enums.SubmissionQuestionResponseType;
 import gov.cabinetoffice.gap.applybackend.enums.SubmissionSectionStatus;
 import gov.cabinetoffice.gap.applybackend.enums.SubmissionStatus;
-import gov.cabinetoffice.gap.applybackend.exception.AttachmentException;
-import gov.cabinetoffice.gap.applybackend.exception.GrantApplicationNotPublishedException;
-import gov.cabinetoffice.gap.applybackend.exception.NotFoundException;
-import gov.cabinetoffice.gap.applybackend.exception.SubmissionAlreadyCreatedException;
+import gov.cabinetoffice.gap.applybackend.exception.*;
 import gov.cabinetoffice.gap.applybackend.model.*;
 import gov.cabinetoffice.gap.applybackend.service.*;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
@@ -587,9 +587,7 @@ class SubmissionControllerTest {
     void updateAttachment_unauthenticatedError(UpdateAttachmentDto update) {
         doThrow(new UnauthorizedException("Unauthorized oh nooo")).when(secretAuthService).authenticateSecret(anyString());
 
-        final ResponseEntity<String> methodResponse = controllerUnderTest.updateAttachment(SUBMISSION_ID, QUESTION_ID_1, update, "topSecretKey");
-
-        assertThat(methodResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThrows(UnauthorizedException.class, () -> controllerUnderTest.updateAttachment(SUBMISSION_ID, QUESTION_ID_1, update, "topSecretKey"));
     }
 
     // it's frightening how simultaneously good and bad this test is

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
@@ -1,5 +1,6 @@
 package gov.cabinetoffice.gap.applybackend.web;
 
+import com.amazonaws.services.cognitoidp.model.UnauthorizedException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import gov.cabinetoffice.gap.applybackend.constants.APIConstants;
 import gov.cabinetoffice.gap.applybackend.dto.api.*;
@@ -22,6 +23,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -43,6 +45,8 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 class SubmissionControllerTest {
@@ -247,6 +251,9 @@ class SubmissionControllerTest {
     private GrantApplicationService grantApplicationService;
     @Mock
     private GrantAttachmentService grantAttachmentService;
+
+    @Mock
+    private SecretAuthService secretAuthService;
     @Mock
     private AttachmentService attachmentService;
 
@@ -257,7 +264,7 @@ class SubmissionControllerTest {
 
     @BeforeEach
     void setup() {
-        controllerUnderTest = new SubmissionController(submissionService, grantApplicantService, grantAttachmentService, grantApplicationService, attachmentService, clock);
+        controllerUnderTest = new SubmissionController(submissionService, grantApplicantService, grantAttachmentService, grantApplicationService, secretAuthService, attachmentService, clock);
     }
 
     @Test
@@ -568,7 +575,7 @@ class SubmissionControllerTest {
 
         final ArgumentCaptor<GrantAttachment> attachmentCaptor = ArgumentCaptor.forClass(GrantAttachment.class);
 
-        final ResponseEntity<String> methodResponse = controllerUnderTest.updateAttachment(SUBMISSION_ID, QUESTION_ID_1, update);
+        final ResponseEntity<String> methodResponse = controllerUnderTest.updateAttachment(SUBMISSION_ID, QUESTION_ID_1, update, "topSecretKey");
 
         assertThat(methodResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(methodResponse.getBody()).isEqualTo("Attachment Updated");
@@ -577,6 +584,17 @@ class SubmissionControllerTest {
         assertThat(attachmentCaptor.getValue().getStatus()).isEqualTo(status);
         assertThat(attachmentCaptor.getValue().getLastUpdated()).isEqualTo(Instant.now(clock));
         assertThat(attachmentCaptor.getValue().getLocation()).isEqualTo(update.getUri());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideGrantAttachmentUpdates")
+    void updateAttachment_unauthenticatedError(UpdateAttachmentDto update) {
+        doThrow(new UnauthorizedException("Unauthorized oh nooo")).when(secretAuthService).authenticateSecret(anyString());
+
+        UnauthorizedException result = assertThrows(UnauthorizedException.class,
+                () -> controllerUnderTest.updateAttachment(SUBMISSION_ID, QUESTION_ID_1, update, "topSecretKey"));
+
+        assertTrue(result.getMessage().contains("Unauthorized oh nooo"));
     }
 
     // it's frightening how simultaneously good and bad this test is

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
@@ -587,10 +587,9 @@ class SubmissionControllerTest {
     void updateAttachment_unauthenticatedError(UpdateAttachmentDto update) {
         doThrow(new UnauthorizedException("Unauthorized oh nooo")).when(secretAuthService).authenticateSecret(anyString());
 
-        UnauthorizedException result = assertThrows(UnauthorizedException.class,
-                () -> controllerUnderTest.updateAttachment(SUBMISSION_ID, QUESTION_ID_1, update, "topSecretKey"));
+        final ResponseEntity<String> methodResponse = controllerUnderTest.updateAttachment(SUBMISSION_ID, QUESTION_ID_1, update, "topSecretKey");
 
-        assertTrue(result.getMessage().contains("Unauthorized oh nooo"));
+        assertThat(methodResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
     }
 
     // it's frightening how simultaneously good and bad this test is


### PR DESCRIPTION
- Adding a secret env value
- Endpoint that lambda calls now expects an Authorization header
- Adding a service that validates this header matches the secret env value
- Throws an UnAuth Exception if it does not match