### PR TITLE
TMI2-425: Cannot submit application

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
@@ -241,24 +241,11 @@ public class SubmissionService {
     }
 
     private void createDiligenceCheckFromSubmission(final Submission submission) {
-        final SubmissionSection essentialInfoSection = submission.getDefinition().getSections()
-                .stream()
-                .filter(section -> section.getSectionId().equals(ESSENTIAL_SECTION_ID))
-                .findAny()
-                .orElseThrow(
-                        () -> new IllegalArgumentException(
-                                "submission does not contain an essential info section"));
-
-        final String organisationName = getResponseBySectionAndQuestionId(essentialInfoSection,
-                APPLICANT_ORG_NAME);
-        final String[] organisationAddress = getMultiResponseBySectionAndQuestionId(essentialInfoSection,
-                APPLICANT_ORG_ADDRESS);
-        final String applicationAmount = getResponseBySectionAndQuestionId(essentialInfoSection,
-                APPLICANT_AMOUNT);
-        final String companiesHouseNumber = getResponseBySectionAndQuestionId(essentialInfoSection,
-                APPLICANT_ORG_COMPANIES_HOUSE);
-        final String charitiesCommissionNumber = getResponseBySectionAndQuestionId(essentialInfoSection,
-                APPLICANT_ORG_CHARITY_NUMBER);
+        final String organisationName = getQuestionResponseByQuestionId(submission, APPLICANT_ORG_NAME);
+        final String[] organisationAddress = getQuestionMultiResponseByQuestionId(submission, APPLICANT_ORG_ADDRESS);
+        final String applicationAmount = getQuestionResponseByQuestionId(submission, APPLICANT_AMOUNT);
+        final String companiesHouseNumber = getQuestionResponseByQuestionId(submission, APPLICANT_ORG_COMPANIES_HOUSE);
+        final String charitiesCommissionNumber = getQuestionResponseByQuestionId(submission, APPLICANT_ORG_CHARITY_NUMBER);
 
         diligenceCheckRepository.save(DiligenceCheck.builder()
                 .submissionId(submission.getId())
@@ -274,16 +261,28 @@ public class SubmissionService {
                 .build());
     }
 
-    private String getResponseBySectionAndQuestionId(final SubmissionSection essentialInfoSection,
-                                                     final String questionId) {
-        return essentialInfoSection.getQuestions()
+    private String getQuestionResponseByQuestionId(final Submission submission, final String questionId) {
+        return submission.getDefinition().getSections()
                 .stream()
+                .flatMap(s -> s.getQuestions().stream())
                 .filter(question -> question.getQuestionId().equals(questionId))
                 .findAny()
                 .orElseThrow(() -> new IllegalArgumentException(
-                        String.format("section %s does not contain a question with an ID of %s",
-                                essentialInfoSection.getSectionId(), questionId)))
+                        String.format("submission %s does not contain a question with an ID of %s",
+                                submission.getId(), questionId)))
                 .getResponse();
+    }
+
+    private String[] getQuestionMultiResponseByQuestionId(final Submission submission, final String questionId) {
+        return submission.getDefinition().getSections()
+                .stream()
+                .flatMap(s -> s.getQuestions().stream())
+                .filter(question -> question.getQuestionId().equals(questionId))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("submission %s does not contain a question with an ID of %s",
+                                submission.getId(), questionId)))
+                .getMultiResponse();
     }
 
     private String[] getMultiResponseBySectionAndQuestionId(final SubmissionSection essentialInfoSection,
@@ -321,22 +320,7 @@ public class SubmissionService {
     }
 
     private void createGrantBeneficiary(final Submission submission) {
-        final SubmissionSection essentialInfoSection = submission.getDefinition().getSections()
-                .stream()
-                .filter(section -> section.getSectionId().equals(ESSENTIAL_SECTION_ID))
-                .findAny()
-                .orElseThrow(
-                        () -> new IllegalArgumentException(
-                                "submission does not contain an essential info section"));
-
-        String[] locations = essentialInfoSection.getQuestions()
-                .stream()
-                .filter(question -> question.getQuestionId().equals(BENEFITIARY_LOCATION))
-                .findAny()
-                .orElseThrow(
-                        () -> new IllegalArgumentException(
-                                "Essential information does not contain a Beneficiary location question"))
-                .getMultiResponse();
+        final String[] locations = getQuestionMultiResponseByQuestionId(submission, BENEFITIARY_LOCATION);
 
         grantBeneficiaryRepository.save(GrantBeneficiary.builder()
                 .schemeId(submission.getScheme().getId())

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
@@ -790,14 +790,25 @@ class SubmissionServiceTest {
         final SubmissionDefinition definitionWithNoEssentialSection = SubmissionDefinition.builder()
                 .sections(Collections.emptyList())
                 .build();
+
         final GrantApplicant grantApplicant = GrantApplicant.builder()
                 .userId(userId)
                 .id(1)
                 .build();
+
+        final GrantScheme scheme = GrantScheme.builder()
+                .version(1)
+                .build();
+
+        final GrantApplication application = GrantApplication.builder()
+                .grantScheme(scheme)
+                .build();
+
         final Submission submissionWithoutEssentialSection = Submission.builder()
                 .definition(definitionWithNoEssentialSection)
                 .status(SubmissionStatus.IN_PROGRESS)
                 .id(SUBMISSION_ID)
+                .application(application)
                 .build();
 
         doReturn(true).when(serviceUnderTest).isSubmissionReadyToBeSubmitted(userId, SUBMISSION_ID);
@@ -814,17 +825,29 @@ class SubmissionServiceTest {
                 .sectionId("ESSENTIAL")
                 .questions(questions)
                 .build();
+
         final GrantApplicant grantApplicant = GrantApplicant.builder()
                 .userId(userId)
                 .id(1)
                 .build();
+
         final SubmissionDefinition definitionWithNoEssentialSection = SubmissionDefinition.builder()
                 .sections(List.of(essentialSection))
                 .build();
+
+        final GrantScheme scheme = GrantScheme.builder()
+                .version(1)
+                .build();
+
+        final GrantApplication application = GrantApplication.builder()
+                .grantScheme(scheme)
+                .build();
+
         final Submission submissionWithoutEssentialSection = Submission.builder()
                 .definition(definitionWithNoEssentialSection)
                 .id(SUBMISSION_ID)
                 .status(SubmissionStatus.IN_PROGRESS)
+                .application(application)
                 .build();
 
         doReturn(true).when(serviceUnderTest).isSubmissionReadyToBeSubmitted(userId, SUBMISSION_ID);


### PR DESCRIPTION
Description of change: 

Added methods to search the entire submission definition fo mandatory question IDs rather than searching within a specified section. This means that if the structure of the mandatory questions changes again in future we won't introduce another breaking change to the code.

Cause: 

The mandatory question information used to live in a section with an ID of `ESSENTIAL` but this has now been split into two new sections and the questions within have been spread across the two. This meant that the code to populate diligence checks and beneficiary information could not find the information it was looking for and was throwing an exception. 

Story: 
https://technologyprogramme.atlassian.net/jira/software/projects/TMI2/boards/331?selectedIssue=TMI2-425 