### PR TITLE
fix(submissions): when creating submission return submission if one already exists

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/repository/SubmissionRepository.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/repository/SubmissionRepository.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 
 public interface SubmissionRepository extends JpaRepository<Submission, UUID> {
     List<Submission> findByApplicantId(long applicantId);
+    Optional<Submission> findByApplicantIdAndApplicationId(long applicantId, Integer applicationId);
 
     Optional<Submission> findByIdAndApplicantUserId(UUID id, String userId);
 }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
@@ -371,6 +371,11 @@ public class SubmissionService {
                 .anyMatch(submission -> submission.getApplication().getId().equals(grantApplication.getId()));
     }
 
+    public Optional<Submission> getSubmissionByApplicantAndApplicationId(GrantApplicant grantApplicant,
+                                                                         GrantApplication grantApplication) {
+        return submissionRepository.findByApplicantIdAndApplicationId(grantApplicant.getId(), grantApplication.getId());
+    }
+
 
     public CreateSubmissionResponseDto createSubmissionFromApplication(final String userId,
                                                                        final GrantApplicant grantApplicant,

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
@@ -63,6 +63,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -488,7 +489,7 @@ class SubmissionControllerTest {
     }
 
     @Test
-    void createApplication__submissionAlreadyExists_ThrowSubmissionAlreadyCreatedException() {
+    void returnSubmission__IfsubmissionAlreadyExists() throws JsonProcessingException {
         when(securityContext.getAuthentication()).thenReturn(authentication);
 
         SecurityContextHolder.setContext(securityContext);
@@ -498,11 +499,14 @@ class SubmissionControllerTest {
         when(grantApplicationService.isGrantApplicationPublished(1)).thenReturn(true);
         when(grantApplicationService.getGrantApplicationById(1)).thenReturn(application);
         when(grantApplicantService.getApplicantById(grantApplicant.getUserId())).thenReturn(grantApplicant);
-        when(submissionService.doesSubmissionExist(grantApplicant, application)).thenReturn(true);
+        when(submissionService.getSubmissionByApplicantAndApplicationId(grantApplicant, application))
+                .thenReturn(Optional.of(submission));
 
-        SubmissionAlreadyCreatedException result = assertThrows(SubmissionAlreadyCreatedException.class, () -> controllerUnderTest.createApplication(1));
+        ResponseEntity<CreateSubmissionResponseDto> response = controllerUnderTest.createApplication(1);
 
-        assertTrue(result.getMessage().contains("SUBMISSION_EXISTS"));
+        assertEquals(response, new ResponseEntity<>(CreateSubmissionResponseDto.builder().submissionCreated(false)
+                .submissionId(submission.getId())
+                .build(), HttpStatus.OK));
     }
 
     @Test


### PR DESCRIPTION
Ticket: https://technologyprogramme.atlassian.net/browse/TMI2-382

Changes create submission behaviour so that if one already exists we return it instead of throwing an error.  The frontend will then redirect appropriately to the submission page.

