### PR TITLE
TMI2-436: Fix Charity Comission + Companies House number validation o…

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/dto/api/UpdateGrantApplicantOrganisationProfileDto.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/dto/api/UpdateGrantApplicantOrganisationProfileDto.java
@@ -46,12 +46,12 @@ public class UpdateGrantApplicantOrganisationProfileDto {
             message = "Postcode must only use letters, numbers, and special characters such as hyphens, spaces and apostrophes")
     private String postcode;
 
-    @Size(max = 250, message = "Charity commission number must be 250 characters or less")
+    @Size(max = 15, message = "Charity commission number must be 15 characters or less")
     @Pattern(regexp = "^(?![\\s\\S])|^[a-zA-Z0-9\\s',-]+$",
             message = "Charity commission number must only use letters, numbers, and special characters such as hyphens, spaces and apostrophes")
     private String charityCommissionNumber;
 
-    @Size(max = 250, message = "Companies house number must be 250 characters or less")
+    @Size(max = 8, message = "Companies house number must be 8 characters or less")
     @Pattern(regexp = "^(?![\\s\\S])|^[a-zA-Z0-9\\s',-]+$",
             message = "Companies house must only use letters, numbers, and special characters such as hyphens, spaces and apostrophes")
     private String companiesHouseNumber;

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
@@ -53,6 +53,16 @@ public class GrantMandatoryQuestionService {
         final GrantApplicantOrganisationProfile organisationProfile = applicant.getOrganisationProfile();
 
         final GrantMandatoryQuestions grantMandatoryQuestions = organisationProfileMapper.mapOrgProfileToGrantMandatoryQuestion(organisationProfile);
+
+        //Fix to exclude any existing Charity Comission Number or Companies House Number which have invalid lengths,
+        //This will force the applicant to go through the MQ journey and update their details with a valid length number
+        if(grantMandatoryQuestions.getCharityCommissionNumber() != null && grantMandatoryQuestions.getCharityCommissionNumber().length() > MandatoryQuestionConstants.CHARITY_COMMISSION_NUMBER_MAX_LENGTH){
+            grantMandatoryQuestions.setCharityCommissionNumber(null);
+        }
+        if(grantMandatoryQuestions.getCompaniesHouseNumber() != null && grantMandatoryQuestions.getCompaniesHouseNumber().length() > MandatoryQuestionConstants.COMPANIES_HOUSE_NUMBER_MAX_LENGTH){
+            grantMandatoryQuestions.setCompaniesHouseNumber(null);
+        }
+
         grantMandatoryQuestions.setGrantScheme(scheme);
         grantMandatoryQuestions.setCreatedBy(applicant);
 

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
@@ -338,9 +338,6 @@ class GrantMandatoryQuestionServiceTest {
                     .charityCommissionNumber(orgProfileWithLongCCandCH.getCharityCommissionNumber())
                     .build();
 
-            when(grantMandatoryQuestionRepository.findByGrantSchemeAndCreatedBy(scheme, applicant))
-                    .thenReturn(Collections.emptyList());
-
             when(grantMandatoryQuestionRepository.save(Mockito.any()))
                     .thenReturn(grantMandatoryQuestions);
 

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
@@ -236,6 +236,59 @@ class GrantMandatoryQuestionServiceTest {
             assertThat(methodResponse).isEqualTo(grantMandatoryQuestions);
         }
 
+        @Test
+        void createMandatoryQuestion_NullsCCandCH_ifTooLong() {
+
+            final GrantScheme scheme = GrantScheme
+                    .builder()
+                    .id(1)
+                    .build();
+
+            final GrantApplicantOrganisationProfile orgProfileWithLongCCandCH = GrantApplicantOrganisationProfile
+                    .builder()
+                    .id(1)
+                    .legalName("legalName")
+                    .addressLine1("addressLine1")
+                    .town("town")
+                    .postcode("postcode")
+                    .companiesHouseNumber("THIS IS A REALLY LONG COMPANIES HOUSE NUMEBR")
+                    .charityCommissionNumber("THIS IS A REALLY LONG CHARITY COMISSION NUMBE")
+                    .build();
+
+            final GrantApplicant applicant = GrantApplicant
+                    .builder()
+                    .userId(applicantUserId)
+                    .organisationProfile(orgProfileWithLongCCandCH)
+                    .build();
+
+            final GrantMandatoryQuestions grantMandatoryQuestions = GrantMandatoryQuestions.builder()
+                    .grantScheme(scheme)
+                    .createdBy(applicant)
+                    .city(orgProfileWithLongCCandCH.getTown())
+                    .name(orgProfileWithLongCCandCH.getLegalName())
+                    .postcode(orgProfileWithLongCCandCH.getPostcode())
+                    .addressLine1(orgProfileWithLongCCandCH.getAddressLine1())
+                    .companiesHouseNumber(orgProfileWithLongCCandCH.getCompaniesHouseNumber())
+                    .charityCommissionNumber(orgProfileWithLongCCandCH.getCharityCommissionNumber())
+                    .build();
+
+            when(grantMandatoryQuestionRepository.findByGrantSchemeAndCreatedBy(scheme, applicant))
+                    .thenReturn(Collections.emptyList());
+
+            when(grantMandatoryQuestionRepository.save(Mockito.any()))
+                    .thenReturn(grantMandatoryQuestions);
+
+            when(organisationProfileMapper.mapOrgProfileToGrantMandatoryQuestion(orgProfileWithLongCCandCH))
+                    .thenReturn(grantMandatoryQuestions);
+
+            final GrantMandatoryQuestions methodResponse = serviceUnderTest.createMandatoryQuestion(scheme, applicant);
+
+            verify(organisationProfileMapper).mapOrgProfileToGrantMandatoryQuestion(orgProfileWithLongCCandCH);
+            verify(grantMandatoryQuestionRepository).save(any());
+            assertThat(methodResponse.getCharityCommissionNumber()).isEqualTo(null);
+            assertThat(methodResponse.getCompaniesHouseNumber()).isEqualTo(null);
+        }
+
     }
 
     @Nested


### PR DESCRIPTION
…n Org Profile.

Check CC & CH length when prepopulating MQs and null value if too long

This should keep any existing data within the CH or CC fields, but if a user tries to edit them they will be forced to enter a new, valid value.
If they go through the MQ journey, if it's too long those values won't be prepopulated and the user will be forced through the whole MQ journey, making them enter a new valid CC and CH number