### PR TITLE
Bug/tmi2 431 section statuses not set correctly

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
@@ -14,17 +14,7 @@ import gov.cabinetoffice.gap.applybackend.enums.SubmissionStatus;
 import gov.cabinetoffice.gap.applybackend.exception.NotFoundException;
 import gov.cabinetoffice.gap.applybackend.exception.SubmissionAlreadySubmittedException;
 import gov.cabinetoffice.gap.applybackend.exception.SubmissionNotReadyException;
-import gov.cabinetoffice.gap.applybackend.model.ApplicationDefinition;
-import gov.cabinetoffice.gap.applybackend.model.DiligenceCheck;
-import gov.cabinetoffice.gap.applybackend.model.GrantApplicant;
-import gov.cabinetoffice.gap.applybackend.model.GrantApplicantOrganisationProfile;
-import gov.cabinetoffice.gap.applybackend.model.GrantApplication;
-import gov.cabinetoffice.gap.applybackend.model.GrantBeneficiary;
-import gov.cabinetoffice.gap.applybackend.model.GrantScheme;
-import gov.cabinetoffice.gap.applybackend.model.Submission;
-import gov.cabinetoffice.gap.applybackend.model.SubmissionDefinition;
-import gov.cabinetoffice.gap.applybackend.model.SubmissionQuestion;
-import gov.cabinetoffice.gap.applybackend.model.SubmissionSection;
+import gov.cabinetoffice.gap.applybackend.model.*;
 import gov.cabinetoffice.gap.applybackend.repository.DiligenceCheckRepository;
 import gov.cabinetoffice.gap.applybackend.repository.GrantBeneficiaryRepository;
 import gov.cabinetoffice.gap.applybackend.repository.SubmissionRepository;
@@ -38,8 +28,6 @@ import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 
 @RequiredArgsConstructor
@@ -134,7 +122,7 @@ public class SubmissionService {
         }
 
         if (sectionId.equals(ELIGIBILITY)) {
-            HandleEligibilitySection(questionResponse, submission);
+            handleEligibilitySection(questionResponse, submission);
         }
 
         submissionRepository.save(submission);
@@ -519,7 +507,7 @@ public class SubmissionService {
         return definition;
     }
 
-    private void HandleEligibilitySection(CreateQuestionResponseDto questionResponse, Submission submission) {
+    private void handleEligibilitySection(CreateQuestionResponseDto questionResponse, Submission submission) {
         if (questionResponse.getResponse().equals("Yes")) {
             final int schemeVersion = submission.getApplication()
                     .getGrantScheme()
@@ -553,8 +541,6 @@ public class SubmissionService {
         sectionIds.add(ELIGIBILITY);
 
         if (schemeVersion > 1) {
-            sectionIds.add(ORGANISATION_DETAILS);
-            sectionIds.add(FUNDING_DETAILS);
             sectionIds.add(ORGANISATION_DETAILS);
             sectionIds.add(FUNDING_DETAILS);
         }

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
@@ -565,7 +565,7 @@ class SubmissionServiceTest {
 
         @Test
         void saveEligibilityResponseToNoAltersStatus_SavesResponse() {
-//        Test checks that if Eligibility is Yes then Not Started is changed to Cannot Start Yet
+
             final CreateQuestionResponseDto questionResponse = CreateQuestionResponseDto.builder()
                     .questionId("ELIGIBILITY")
                     .submissionId(SUBMISSION_ID)

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
@@ -186,7 +186,7 @@ class SubmissionServiceTest {
                 .build();
 
         SubmissionDefinition definition = SubmissionDefinition.builder()
-                .sections(List.of(section, eligibilitySection, sectionNotStarted, sectionCannotStartYet))
+                .sections(new ArrayList(List.of(section, eligibilitySection, sectionNotStarted, sectionCannotStartYet)))
                 .build();
 
         final GrantApplicant grantApplicant = GrantApplicant.builder().id(1)
@@ -564,6 +564,99 @@ class SubmissionServiceTest {
         }
 
         @Test
+        void saveQuestionResponse_HandlesV2Schemes_WhenEligibilityResponse_IsYes() {
+
+            // set the scheme to version 2
+            submission.getApplication().getGrantScheme().setVersion(2);
+
+            // remove eligibility section
+            submission.getDefinition()
+                    .getSections()
+                    .removeIf(section -> section.getSectionId().equals("ESSENTIAL"));
+
+            // add organisation details and funding details sections
+            final SubmissionSection orgDetails = SubmissionSection.builder()
+                    .sectionId("ORGANISATION_DETAILS")
+                    .sectionStatus(SubmissionSectionStatus.CANNOT_START_YET)
+                    .build();
+
+            final SubmissionSection fundingDetails = SubmissionSection.builder()
+                    .sectionId("FUNDING_DETAILS")
+                    .sectionStatus(SubmissionSectionStatus.CANNOT_START_YET)
+                    .build();
+
+            submission.getDefinition()
+                    .getSections()
+                    .add(1, orgDetails);
+
+            submission.getDefinition()
+                    .getSections()
+                    .add(2, fundingDetails);
+
+            final CreateQuestionResponseDto questionResponse = CreateQuestionResponseDto.builder()
+                    .questionId("ELIGIBILITY")
+                    .submissionId(SUBMISSION_ID)
+                    .response("Yes")
+                    .build();
+
+            doReturn(submission)
+                    .when(serviceUnderTest).getSubmissionFromDatabaseBySubmissionId(userId, SUBMISSION_ID);
+
+            final ArgumentCaptor<Submission> submissionCaptor = ArgumentCaptor.forClass(Submission.class);
+
+
+            serviceUnderTest.saveQuestionResponse(questionResponse, userId, SUBMISSION_ID, "ELIGIBILITY");
+
+
+            verify(submissionRepository).save(submissionCaptor.capture());
+
+            submissionCaptor.getValue()
+                    .getDefinition()
+                    .getSections()
+                    .stream()
+                    .filter(section -> section.getSectionId().equals(SECTION_ID_SECTION_CANNOT_START_YET))
+                    .findFirst()
+                    .ifPresentOrElse(
+                            capturedSectionResponse -> assertThat(capturedSectionResponse.getSectionStatus()).isEqualTo(SubmissionSectionStatus.NOT_STARTED),
+                            () -> fail(String.format("No section with ID '%s' found", SECTION_ID_SECTION_CANNOT_START_YET))
+                    );
+
+            submissionCaptor.getValue()
+                    .getDefinition()
+                    .getSections()
+                    .stream()
+                    .filter(section -> section.getSectionId().equals(SECTION_ID_NOT_STARTED))
+                    .findFirst()
+                    .ifPresentOrElse(
+                            capturedSectionResponse -> assertThat(capturedSectionResponse.getSectionStatus()).isEqualTo(SubmissionSectionStatus.NOT_STARTED),
+                            () -> fail(String.format("No section with ID '%s' found", SECTION_ID_NOT_STARTED))
+                    );
+
+            // organisation details and funding details should be set to in progress
+            submissionCaptor.getValue()
+                    .getDefinition()
+                    .getSections()
+                    .stream()
+                    .filter(section -> section.getSectionId().equals("ORGANISATION_DETAILS"))
+                    .findFirst()
+                    .ifPresentOrElse(
+                            capturedSectionResponse -> assertThat(capturedSectionResponse.getSectionStatus()).isEqualTo(SubmissionSectionStatus.IN_PROGRESS),
+                            () -> fail(String.format("No section with ID 'ORGANISATION_DETAILS' found"))
+                    );
+
+            submissionCaptor.getValue()
+                    .getDefinition()
+                    .getSections()
+                    .stream()
+                    .filter(section -> section.getSectionId().equals("FUNDING_DETAILS"))
+                    .findFirst()
+                    .ifPresentOrElse(
+                            capturedSectionResponse -> assertThat(capturedSectionResponse.getSectionStatus()).isEqualTo(SubmissionSectionStatus.IN_PROGRESS),
+                            () -> fail(String.format("No section with ID 'FUNDING_DETAILS' found"))
+                    );
+        }
+
+        @Test
         void saveEligibilityResponseToNoAltersStatus_SavesResponse() {
 
             final CreateQuestionResponseDto questionResponse = CreateQuestionResponseDto.builder()
@@ -602,6 +695,63 @@ class SubmissionServiceTest {
                             capturedSectionResponse -> assertThat(capturedSectionResponse.getSectionStatus()).isEqualTo(SubmissionSectionStatus.CANNOT_START_YET),
                             () -> fail(String.format("No section with ID '%s' found", SECTION_ID_NOT_STARTED))
                     );
+
+            // This seems like a strange assertion but it tests that any section that has already been started isn't flipped back to not started or cannot start yet.
+            submissionCaptor.getValue()
+                    .getDefinition()
+                    .getSections()
+                    .stream()
+                    .filter(section -> section.getSectionId().equals(SECTION_ID_1))
+                    .findFirst()
+                    .ifPresentOrElse(
+                            capturedSectionResponse -> assertThat(capturedSectionResponse.getSectionStatus()).isEqualTo(SubmissionSectionStatus.IN_PROGRESS),
+                            () -> fail(String.format("No section with ID '%s' found", SECTION_ID_1))
+                    );
+        }
+
+        @Test
+        void saveQuestionResponse_HandlesV2Schemes_WhenEligibilityResponse_IsNo() {
+
+            // set the scheme to version 2
+            submission.getApplication().getGrantScheme().setVersion(2);
+
+            final CreateQuestionResponseDto questionResponse = CreateQuestionResponseDto.builder()
+                    .questionId("ELIGIBILITY")
+                    .submissionId(SUBMISSION_ID)
+                    .response("No")
+                    .build();
+
+            doReturn(submission)
+                    .when(serviceUnderTest).getSubmissionFromDatabaseBySubmissionId(userId, SUBMISSION_ID);
+
+            final ArgumentCaptor<Submission> submissionCaptor = ArgumentCaptor.forClass(Submission.class);
+
+            serviceUnderTest.saveQuestionResponse(questionResponse, userId, SUBMISSION_ID, "ELIGIBILITY");
+
+            verify(submissionRepository).save(submissionCaptor.capture());
+
+            submissionCaptor.getValue()
+                    .getDefinition()
+                    .getSections()
+                    .stream()
+                    .filter(section -> section.getSectionId().equals(SECTION_ID_SECTION_CANNOT_START_YET))
+                    .findFirst()
+                    .ifPresentOrElse(
+                            capturedSectionResponse -> assertThat(capturedSectionResponse.getSectionStatus()).isEqualTo(SubmissionSectionStatus.CANNOT_START_YET),
+                            () -> fail(String.format("No section with ID '%s' found", SECTION_ID_SECTION_CANNOT_START_YET))
+                    );
+
+            submissionCaptor.getValue()
+                    .getDefinition()
+                    .getSections()
+                    .stream()
+                    .filter(section -> section.getSectionId().equals(SECTION_ID_NOT_STARTED))
+                    .findFirst()
+                    .ifPresentOrElse(
+                            capturedSectionResponse -> assertThat(capturedSectionResponse.getSectionStatus()).isEqualTo(SubmissionSectionStatus.CANNOT_START_YET),
+                            () -> fail(String.format("No section with ID '%s' found", SECTION_ID_NOT_STARTED))
+                    );
+
 
             submissionCaptor.getValue()
                     .getDefinition()


### PR DESCRIPTION
Handles section statuses for both V1 and V2 grants. 

For V1 grants: 
- Sections should all be set to "cannot start yet" if eligibility has been marked as no or hasn't been started. 
- Section statuses should all switch to "not started" if eligibility is marked as "yes". 
- If a user goes back and marks eligibility as "no" then all sections should go back to cannot start yet, unless the section has already been started, then the section status should remain unchanged. 

For V2 grants: 
- All of the above should apply with the exception of two sections: organisation details and funding details. 
- upon completion of eligibility, organisation details and funding details should immediately move to in progress. 

