### PR TITLE
TMI2-479 -Adding 'isPublished' property to grant advert DTOs

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/dto/api/GetGrantAdvertDto.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/dto/api/GetGrantAdvertDto.java
@@ -31,4 +31,6 @@ public class GetGrantAdvertDto {
     private boolean isAdvertInDatabase;
 
     private GetGrantMandatoryQuestionDto mandatoryQuestionsDto;
+
+    private boolean isPublished;
 }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantAdvertService.java
@@ -7,6 +7,7 @@ import com.contentful.java.cda.CDAEntry;
 import com.contentful.java.cda.CDAResourceNotFoundException;
 import gov.cabinetoffice.gap.applybackend.dto.api.GetGrantAdvertDto;
 import gov.cabinetoffice.gap.applybackend.dto.api.GetGrantMandatoryQuestionDto;
+import gov.cabinetoffice.gap.applybackend.enums.GrantAdvertStatus;
 import gov.cabinetoffice.gap.applybackend.exception.NotFoundException;
 import gov.cabinetoffice.gap.applybackend.mapper.GrantMandatoryQuestionMapper;
 import gov.cabinetoffice.gap.applybackend.model.GrantAdvert;
@@ -63,6 +64,7 @@ public class GrantAdvertService {
                 .grantSchemeId(advert.getScheme().getId())
                 .isAdvertInDatabase(true)
                 .mandatoryQuestionsDto(mandatoryQuestions)
+                .isPublished(advert.getStatus() == GrantAdvertStatus.PUBLISHED)
                 .build();
     }
 


### PR DESCRIPTION
## Description

Ticket # and link

As part of the fix for https://technologyprogramme.atlassian.net/browse/TMI2-479 , we need to know whether a grant advert has been published or not. This change adds an 'isPublished' property to grant advert response DTOs.

## Type of change

Please check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [X] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
