### PR TITLE
TMI2-484: Fix GAP ID Generation

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
@@ -95,9 +95,7 @@ public class GrantMandatoryQuestionService {
 
     public GrantMandatoryQuestions updateMandatoryQuestion(GrantMandatoryQuestions grantMandatoryQuestions, GrantApplicant grantApplicant) {
         if (grantMandatoryQuestions.getStatus().equals(GrantMandatoryQuestionStatus.COMPLETED)) {
-            final Submission submission = grantMandatoryQuestions.getSubmission();
-            final String gapId = submission == null ? GapIdGenerator
-                    .generateGapId(grantApplicant.getId(), envProperties.getEnvironmentName(), grantMandatoryQuestionRepository.count(), true) : submission.getGapId();
+            final String gapId = GapIdGenerator.generateGapId(grantApplicant.getId(), envProperties.getEnvironmentName(), grantMandatoryQuestionRepository.count(), 2);
             grantMandatoryQuestions.setGapId(gapId);
         }
         return grantMandatoryQuestionRepository

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
@@ -221,17 +221,21 @@ public class SubmissionService {
         }
 
         final long diligenceCheckRecordsFromToday = getDiligenceCheckRecordsCountFromToday();
+        final int version = submission.getScheme().getVersion();
 
-        final String gapId = GapIdGenerator.generateGapId(
-                grantApplicant.getId(),
-                envProperties.getEnvironmentName(),
-                diligenceCheckRecordsFromToday + 1,
-                false
-        );
-        submission.setGapId(gapId);
-        if (submission.getScheme().getVersion() > 1) {
-            setMandatoryQuestionsGapId(submission);
+        final Optional<GrantMandatoryQuestions> grantMandatoryQuestion = grantMandatoryQuestionRepository.findBySubmissionId(submission.getId());
+        final String gapId;
+        if (grantMandatoryQuestion.isPresent()) {
+            gapId = grantMandatoryQuestion.get().getGapId();
+        } else {
+            gapId = GapIdGenerator.generateGapId(
+                    grantApplicant.getId(),
+                    envProperties.getEnvironmentName(),
+                    diligenceCheckRecordsFromToday + 1,
+                    version
+            );
         }
+        submission.setGapId(gapId);
 
         submitApplication(submission);
         notifyClient.sendConfirmationEmail(emailAddress, submission);

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/utils/GapIdGenerator.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/utils/GapIdGenerator.java
@@ -5,7 +5,7 @@ import java.time.format.DateTimeFormatter;
 
 public class GapIdGenerator {
 
-    public static String generateGapId(final Long userId, final String env, final long recordNumber, final boolean isMandatoryQuestion) {
+    public static String generateGapId(final Long userId, final String env, final long recordNumber, final int version) {
         final LocalDate currentDate = LocalDate.now();
         final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
         final String date = currentDate.format(formatter);
@@ -13,10 +13,10 @@ public class GapIdGenerator {
         return "GAP" +
                 "-" +
                 env +
-                (isMandatoryQuestion ?
-                        "-MQ-" : "-") +
+                "-" +
                 date +
                 "-" +
+                version +
                 recordNumber +
                 "-" +
                 userId

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
@@ -21,6 +21,8 @@ import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -381,6 +383,11 @@ class GrantMandatoryQuestionServiceTest {
         @Test
         void updateMandatoryQuestion_UpdatesExpectedMandatoryQuestionsAndSetsGapId() {
             final UUID mandatoryQuestionsId = UUID.randomUUID();
+
+            final LocalDate currentDate = LocalDate.now();
+            final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+            final String date = currentDate.format(formatter);
+
             final GrantMandatoryQuestions grantMandatoryQuestions = GrantMandatoryQuestions
                     .builder()
                     .id(mandatoryQuestionsId)
@@ -398,31 +405,10 @@ class GrantMandatoryQuestionServiceTest {
 
             verify(grantMandatoryQuestionRepository).save(grantMandatoryQuestions);
             assertThat(methodResponse).isEqualTo(grantMandatoryQuestions);
-            assertThat(methodResponse.getGapId()).contains("GAP-local-MQ-");
+
+            //GAP ID Should be GAP-{environment}-{date}-{version}{recordNumber}-{userId}
+            assertThat(methodResponse.getGapId()).isEqualTo("GAP-"+ "local" + "-" + date + "-22-1");
             assertThat(methodResponse.getGapId()).isEqualTo(grantMandatoryQuestions.getGapId());
-        }
-
-        @Test
-        void updateMandatoryQuestion_UpdatesExpectedMandatoryQuestionsAndSetsGapIdBySubmission() {
-            final UUID mandatoryQuestionsId = UUID.randomUUID();
-            final Submission submission = Submission.builder().gapId("GAP-ID").build();
-            final GrantMandatoryQuestions grantMandatoryQuestions = GrantMandatoryQuestions
-                    .builder()
-                    .id(mandatoryQuestionsId)
-                    .status(GrantMandatoryQuestionStatus.COMPLETED)
-                    .submission(submission)
-                    .build();
-
-            when(grantMandatoryQuestionRepository.findById(mandatoryQuestionsId))
-                    .thenReturn(Optional.of(grantMandatoryQuestions));
-            when(grantMandatoryQuestionRepository.save(grantMandatoryQuestions))
-                    .thenReturn(grantMandatoryQuestions);
-
-            final GrantMandatoryQuestions methodResponse = serviceUnderTest.updateMandatoryQuestion(grantMandatoryQuestions, grantApplicant);
-
-            verify(grantMandatoryQuestionRepository).save(grantMandatoryQuestions);
-            assertThat(methodResponse).isEqualTo(grantMandatoryQuestions);
-            assertThat(methodResponse.getGapId()).isEqualTo(submission.getGapId());
         }
     }
 


### PR DESCRIPTION
## Description

https://technologyprogramme.atlassian.net/browse/TMI2-484

Changed the way GAP IDs are generated. Mandatory Questions will always have a GAP ID assigned when they are completed. When a submission is completed, if it has an attached MQ record (ie a V2 scheme) it will use the GAP ID from that, otherwise it will continue to use the existing generation logic.

Also added an identifier to the GAP ID for which version of the scheme it is.

## Type of change

Please check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [X] Unit Test
- [ ] Integration Test (if applicable)
- [ ] End to End Test (if applicable)

Also manual testing to ensure downloading required checks works as expected.

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
