### PR TITLE
eligibility section bug on v2 schemes

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
@@ -531,8 +531,12 @@ public class SubmissionService {
                     .getVersion();
 
             if (schemeVersion > 1) {
-                submission.getSection(ORGANISATION_DETAILS).setSectionStatus(SubmissionSectionStatus.IN_PROGRESS);
-                submission.getSection(FUNDING_DETAILS).setSectionStatus(SubmissionSectionStatus.IN_PROGRESS);
+                if (submission.getSection(ORGANISATION_DETAILS).getSectionStatus().equals(SubmissionSectionStatus.CANNOT_START_YET)) {
+                    submission.getSection(ORGANISATION_DETAILS).setSectionStatus(SubmissionSectionStatus.IN_PROGRESS);
+                }
+                if (submission.getSection(FUNDING_DETAILS).getSectionStatus().equals(SubmissionSectionStatus.CANNOT_START_YET)) {
+                    submission.getSection(FUNDING_DETAILS).setSectionStatus(SubmissionSectionStatus.IN_PROGRESS);
+                }
             }
 
             submission.getDefinition()


### PR DESCRIPTION
- Fixed a bug where revisiting the eligibility section and re-submitting the answer as "yes" would reset other section statuses.

## Description

Ticket # and link

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
