### PR TITLE
GAP-2341: Cleanup attachments properly

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/config/properties/S3ConfigProperties.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/config/properties/S3ConfigProperties.java
@@ -19,4 +19,7 @@ public class S3ConfigProperties {
 
     @NotNull
     private String bucket;
+
+    @NotNull
+    private String attachmentsBucket;
 }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/AttachmentService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/AttachmentService.java
@@ -59,6 +59,7 @@ public class AttachmentService {
             final AmazonS3URI s3Uri = new AmazonS3URI(attachment.getLocation());
             final String key = applicationId + "/" + submissionId + "/" + questionId + "/" + attachment.getFilename();
             s3Client.deleteObject(new DeleteObjectRequest(s3Uri.getBucket(), key));
+            s3Client.deleteObject(new DeleteObjectRequest(s3Properties.getAttachmentsBucket(), key));
             grantAttachmentRepository.delete(attachment);
         } catch (SdkClientException e) {
             log.error("An error occurred deleting the file: ", e);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,7 +20,8 @@ user-service.domain=http://localhost:8082
 user-service.cookieName=user-service-token
 
 # AWS Configuration
-aws.bucket=a-bucket
+aws.bucket=uploads
+aws.attachmentsBucket=attachments
 
 # Logging
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG


### PR DESCRIPTION
## Description

[Ticket GAP-2341](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2341)

Summary of the changes and the related issue. List any dependencies that are required for this change:
- Attachments wound up in a different bucket than what our delete endpoint attempts to delete from
- Now deleting from both buckets as it may exist in either depending on when the virus scan lambda processes them

Dependent on:
- https://eu-west-2.console.aws.amazon.com/codesuite/codecommit/repositories/GAP-infra/pull-requests/201/details?region=eu-west-2

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [x] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
