### PR TITLE
GAP-2349: Fix open redirects

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantAdvertService.java
@@ -110,8 +110,9 @@ public class GrantAdvertService {
             if (!url.equals(grantWebpageUrl)) {
                 throw new NotFoundException("Grant webpage url does not match the url in contentful");
             }
-        } catch (CDAResourceNotFoundException e) {
+        } catch (CDAResourceNotFoundException error) {
             log.info(String.format("Advert with slug %s not found in Contentful", contentfulSlug));
+            throw error;
         }
     }
 

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantAdvertService.java
@@ -88,8 +88,8 @@ public class GrantAdvertService {
     }
 
     private String getGrantWebpageUrl(final CDAArray contentfulEntry){
-        CDAResource entry = contentfulEntry.items().get(0);
-        Map<String, Object> rawFields = ((CDAEntry) entry).rawFields();
+        CDAEntry entry = ((CDAEntry) contentfulEntry.items().get(0));
+        Map<String, Object> rawFields = entry.rawFields();
         Optional<String> optionalUrl = ((Map<String, String>) rawFields.get("grantWebpageUrl")).values().stream().findFirst();
         if(optionalUrl.isEmpty()){
             throw new NotFoundException("Grant webpage url not found");

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantAdvertService.java
@@ -1,10 +1,7 @@
 package gov.cabinetoffice.gap.applybackend.service;
 
 
-import com.contentful.java.cda.CDAArray;
-import com.contentful.java.cda.CDAClient;
-import com.contentful.java.cda.CDAEntry;
-import com.contentful.java.cda.CDAResourceNotFoundException;
+import com.contentful.java.cda.*;
 import gov.cabinetoffice.gap.applybackend.dto.api.GetGrantAdvertDto;
 import gov.cabinetoffice.gap.applybackend.dto.api.GetGrantMandatoryQuestionDto;
 import gov.cabinetoffice.gap.applybackend.exception.NotFoundException;
@@ -22,6 +19,7 @@ import org.springframework.stereotype.Service;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -90,8 +88,9 @@ public class GrantAdvertService {
     }
 
     private String getGrantWebpageUrl(final CDAArray contentfulEntry){
-        Optional<String> optionalUrl = ((HashMap<String, String>) ((CDAEntry) contentfulEntry.items().get(0))
-                .rawFields().get("grantWebpageUrl")).values().stream().findFirst();
+        CDAResource entry = contentfulEntry.items().get(0);
+        Map<String, Object> rawFields = ((CDAEntry) entry).rawFields();
+        Optional<String> optionalUrl = ((Map<String, String>) rawFields.get("grantWebpageUrl")).values().stream().findFirst();
         if(optionalUrl.isEmpty()){
             throw new NotFoundException("Grant webpage url not found");
         }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantAdvertService.java
@@ -111,7 +111,7 @@ public class GrantAdvertService {
                 throw new NotFoundException("Grant webpage url does not match the url in contentful");
             }
         } catch (CDAResourceNotFoundException error) {
-            log.info(String.format("Advert with slug %s not found in Contentful", contentfulSlug));
+            log.error(String.format("Advert with slug %s not found in Contentful", contentfulSlug));
             throw error;
         }
     }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantAdvertController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantAdvertController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.constraints.NotBlank;
+import java.net.URL;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -99,7 +100,6 @@ public class GrantAdvertController {
         return ResponseEntity.ok(grantAdvertService.generateGetGrantAdvertDto(advert, mandatoryQuestionsDto));
     }
 
-
     @GetMapping("{advertSlug}/exists-in-contentful")
     @Operation(summary = "Check whether a grant advert exists in Contentful with the given slug")
     @ApiResponses(value = {
@@ -107,6 +107,7 @@ public class GrantAdvertController {
             @ApiResponse(responseCode = "400", description = "Required path variable not provided in expected format",
                     content = @Content(mediaType = "application/json"))
     })
+    
     public ResponseEntity<GetContentfulAdvertExistsDto> advertExistsInContentful(@PathVariable final String advertSlug) {
         final boolean advertExists = grantAdvertService.advertExistsInContentful(advertSlug);
 
@@ -116,5 +117,14 @@ public class GrantAdvertController {
                         .isAdvertInContentful(advertExists)
                         .build()
         );
+    }
+
+    @GetMapping("/validate-grant-webpage-url")
+    @Operation(summary = "Check if a grant webpage url matches the grant-webpage-url attached to the slug")
+    public ResponseEntity<String> validateGrantWebpageUrl(
+            @RequestParam @NotBlank String contentfulSlug,@RequestParam @NotBlank String grantWebpageUrl) {
+        grantAdvertService.validateGrantWebpageUrl(contentfulSlug, grantWebpageUrl);
+
+        return ResponseEntity.ok("Success");
     }
 }

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantAdvertControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantAdvertControllerTest.java
@@ -28,7 +28,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class GrantAdvertControllerTest {
@@ -202,6 +202,35 @@ class GrantAdvertControllerTest {
                     .thenThrow(IllegalArgumentException.class);
 
             assertThrows(IllegalArgumentException.class, () -> grantAdvertController.generateGetGrantAdvertDtoFromSchemeId(String.valueOf(schemeId)));
+        }
+    }
+
+    @Nested
+    class validateGrantWebpageUrl {
+        @Test
+        void validatesGrantWebpageUrl_returnsSuccessWithValidArgs(){
+            final String grantWebpageUrl = "https://www.example.com/external-advert";
+            final String contentfulSlug = "internal-contentful-slug";
+            doNothing().when(grantAdvertService).validateGrantWebpageUrl(grantWebpageUrl, contentfulSlug);
+            ResponseEntity<String> response = grantAdvertController.validateGrantWebpageUrl(grantWebpageUrl, contentfulSlug);
+
+            assertThat(response).isEqualTo(ResponseEntity.ok("Success"));
+        }
+
+        @Test
+        void validatesGrantWebpageUrl_returnsNotFound(){
+            final String grantWebpageUrl = "https://www.maliciousdomain.com/extenal";
+            final String contentfulSlug = "internal-contentful-slug";
+            doThrow(NotFoundException.class).when(grantAdvertService).validateGrantWebpageUrl(grantWebpageUrl, contentfulSlug);
+            assertThrows(NotFoundException.class, ()-> grantAdvertController.validateGrantWebpageUrl(grantWebpageUrl, contentfulSlug));
+        }
+
+        @Test
+        void validatesGrantWebpageUrl_ThrowsNotFoundException(){
+            final String grantWebpageUrl = "https://www.maliciousdomain.com/extenal";
+            final String contentfulSlug = "internal-contentful-slug";
+            doThrow(NotFoundException.class).when(grantAdvertService).validateGrantWebpageUrl(grantWebpageUrl, contentfulSlug);
+            assertThrows(NotFoundException.class, ()-> grantAdvertController.validateGrantWebpageUrl(grantWebpageUrl, contentfulSlug));
         }
     }
 }


### PR DESCRIPTION
## Description

Ticket # and link

https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2349

Adds an endpoint to validate a redirectUrl against the grantWebpageUrl attached to a contentful entry.

related prs: 
user-service: https://github.com/cabinetoffice/gap-user-service/pull/167
Applicant fe: https://github.com/cabinetoffice/gap-find-apply-web/pull/221/files

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
