### PR TITLE
TD-150: returns true or false based on eligibility section response

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
@@ -204,7 +204,7 @@ public class SubmissionService {
                 .toList()
                 .isEmpty();
 
-        boolean isEligible = sections.stream()
+        final boolean isEligible = sections.stream()
                 .flatMap(section -> section.getQuestions().stream())
                 .noneMatch(question -> question.getQuestionId().equals("ELIGIBILITY") && !question.getResponse().equals("Yes"));
 

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
@@ -204,7 +204,11 @@ public class SubmissionService {
                 .toList()
                 .isEmpty();
 
-        return questionsAreAllAnswered && sectionAreAllCompleted;
+        boolean isEligible = sections.stream()
+                .flatMap(section -> section.getQuestions().stream())
+                .noneMatch(question -> question.getQuestionId().equals("ELIGIBILITY") && !question.getResponse().equals("Yes"));
+
+        return questionsAreAllAnswered && sectionAreAllCompleted && isEligible;
     }
 
     @Transactional
@@ -567,6 +571,12 @@ public class SubmissionService {
         }
 
         return sectionIds;
+    }
+
+    public boolean isApplicantEligible(final String userId, final UUID submissionId, final String questionId){
+        final Submission submission = getSubmissionFromDatabaseBySubmissionId(userId, submissionId);
+        final Optional<SubmissionQuestion> eligibilityResponse = getQuestionResponseByQuestionId(submission ,"ELIGIBILITY");
+        return eligibilityResponse.map(submissionQuestion -> submissionQuestion.getResponse().equals("Yes")).orElse(false);
     }
 }
 

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
@@ -3,20 +3,16 @@ package gov.cabinetoffice.gap.applybackend.web;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import gov.cabinetoffice.gap.applybackend.constants.APIConstants;
 import gov.cabinetoffice.gap.applybackend.dto.api.*;
-import gov.cabinetoffice.gap.eventservice.enums.EventType;
 import gov.cabinetoffice.gap.applybackend.enums.GrantAttachmentStatus;
 import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionOrgType;
 import gov.cabinetoffice.gap.applybackend.enums.SubmissionSectionStatus;
 import gov.cabinetoffice.gap.applybackend.exception.AttachmentException;
 import gov.cabinetoffice.gap.applybackend.exception.GrantApplicationNotPublishedException;
-import gov.cabinetoffice.gap.eventservice.exception.InvalidEventException;
 import gov.cabinetoffice.gap.applybackend.exception.NotFoundException;
 import gov.cabinetoffice.gap.applybackend.model.*;
 import gov.cabinetoffice.gap.applybackend.service.*;
-
-import static gov.cabinetoffice.gap.applybackend.utils.SecurityContextHelper.getJwtIdFromSecurityContext;
-import static gov.cabinetoffice.gap.applybackend.utils.SecurityContextHelper.getUserIdFromSecurityContext;
-
+import gov.cabinetoffice.gap.eventservice.enums.EventType;
+import gov.cabinetoffice.gap.eventservice.exception.InvalidEventException;
 import gov.cabinetoffice.gap.eventservice.service.EventLogService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,11 +25,13 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.*;
+
+import static gov.cabinetoffice.gap.applybackend.utils.SecurityContextHelper.getJwtIdFromSecurityContext;
+import static gov.cabinetoffice.gap.applybackend.utils.SecurityContextHelper.getUserIdFromSecurityContext;
 
 // TODO This class could probably be broken up into a few smaller more targeted classes
 @Slf4j
@@ -346,6 +344,12 @@ public class SubmissionController {
                                                                                @RequestParam(required = false, defaultValue = "false") final boolean saveAndExit) {
         final String applicantId = getUserIdFromSecurityContext();
         return ResponseEntity.ok(submissionService.getNextNavigation(applicantId, submissionId, sectionId, questionId, saveAndExit));
+    }
+
+    @GetMapping("/{submissionId}/isApplicantEligible")
+    public ResponseEntity<Boolean>  isApplicantEligible(@PathVariable final UUID submissionId) {
+        final String applicantId = getUserIdFromSecurityContext();
+        return ResponseEntity.ok(submissionService.isApplicantEligible(applicantId, submissionId, "ELIGIBILITY"));
     }
 
     private GetSubmissionDto buildSubmissionDto(Submission submission) {

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
@@ -1491,5 +1491,45 @@ class SubmissionServiceTest {
         }
     }
 
+    @Nested
+    class isApplicantEligible {
+        @Test
+        void isApplicantEligible_returnTrue() {
+            when(submissionRepository.findByIdAndApplicantUserId(SUBMISSION_ID, userId))
+                    .thenReturn(Optional.ofNullable(submission));
+
+            final boolean result = serviceUnderTest.isApplicantEligible(userId, SUBMISSION_ID, "ELIGIBILITY");
+
+            verify(submissionRepository).findByIdAndApplicantUserId(SUBMISSION_ID, userId);
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void isApplicantEligible_returnFalse() {
+            final SubmissionQuestion eligibilityQuestion = SubmissionQuestion.builder()
+                    .questionId("ELIGIBILITY")
+                    .response("No")
+                    .validation(null)
+                    .build();
+
+            final SubmissionSection eligibilitySection = SubmissionSection.builder()
+                    .sectionId("ELIGIBILITY")
+                    .sectionStatus(SubmissionSectionStatus.COMPLETED)
+                    .questions(List.of(eligibilityQuestion))
+                    .build();
+            submission.getDefinition().getSections().set(0,eligibilitySection);
+
+            when(submissionRepository.findByIdAndApplicantUserId(SUBMISSION_ID, userId))
+                    .thenReturn(Optional.ofNullable(submission));
+
+            final boolean result = serviceUnderTest.isApplicantEligible(userId, SUBMISSION_ID, "ELIGIBILITY");
+
+            verify(submissionRepository).findByIdAndApplicantUserId(SUBMISSION_ID, userId);
+
+            assertThat(result).isFalse();
+        }
+
+    }
 
 }

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
@@ -32,7 +32,6 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.servlet.http.HttpServletRequest;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -1000,5 +999,29 @@ class SubmissionControllerTest {
         assertThat(methodResponse.getBody()).isEqualTo(expectedNav);
     }
 
+    @Nested
+    class isApplicantEligible {
+        @Test
+        void isApplicantEligible_ReturnsExpectedResponse_ReturnTrue() {
+            when(submissionService.isApplicantEligible(APPLICANT_USER_ID, SUBMISSION_ID, "ELIGIBILITY"))
+                    .thenReturn(true);
+
+            final ResponseEntity<Boolean> response = controllerUnderTest.isApplicantEligible(SUBMISSION_ID);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isTrue();
+        }
+
+        @Test
+        void isApplicantEligible_ReturnsExpectedResponse_ReturnFalse() {
+            when(submissionService.isApplicantEligible(APPLICANT_USER_ID, SUBMISSION_ID, "ELIGIBILITY"))
+                    .thenReturn(false);
+
+            final ResponseEntity<Boolean> response = controllerUnderTest.isApplicantEligible(SUBMISSION_ID);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isFalse();
+        }
+    }
 
 }


### PR DESCRIPTION
## Description
Returns true if eligibility section response is 'Yes', otherwise it returns false. This is needed so that the user cannot submit an application if they have selected 'No' for the eligibility section  

Ticket # and link
TD-150: https://technologyprogramme.atlassian.net/browse/TD-150

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
