### PR TITLE
GAP-2096 | conditionally don't reset section status to in progress

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/dto/api/CreateQuestionResponseDto.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/dto/api/CreateQuestionResponseDto.java
@@ -14,4 +14,5 @@ public class CreateQuestionResponseDto {
     private String questionId;
     private String response;
     private String[] multiResponse;
+    private Boolean sectionComplete;
 }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/dto/api/CreateQuestionResponseDto.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/dto/api/CreateQuestionResponseDto.java
@@ -14,5 +14,5 @@ public class CreateQuestionResponseDto {
     private String questionId;
     private String response;
     private String[] multiResponse;
-    private Boolean sectionComplete;
+    private Boolean shouldUpdateSectionStatus;
 }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
@@ -120,14 +120,14 @@ public class SubmissionService {
 
         if (questionResponse.getResponse() != null) {
             submissionQuestion.setResponse(questionResponse.getResponse());
-            if (questionResponse.getSectionComplete() != true) {
+            if (questionResponse.getShouldUpdateSectionStatus()) {
                 submissionSection.setSectionStatus(SubmissionSectionStatus.IN_PROGRESS);
             }
         }
 
         if (questionResponse.getMultiResponse() != null) {
             submissionQuestion.setMultiResponse(questionResponse.getMultiResponse());
-            if (questionResponse.getSectionComplete() != true) {
+            if (questionResponse.getShouldUpdateSectionStatus()) {
                 submissionSection.setSectionStatus(SubmissionSectionStatus.IN_PROGRESS);
             }
         }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
@@ -120,12 +120,16 @@ public class SubmissionService {
 
         if (questionResponse.getResponse() != null) {
             submissionQuestion.setResponse(questionResponse.getResponse());
-            submissionSection.setSectionStatus(SubmissionSectionStatus.IN_PROGRESS);
+            if (questionResponse.getSectionComplete() != true) {
+                submissionSection.setSectionStatus(SubmissionSectionStatus.IN_PROGRESS);
+            }
         }
 
         if (questionResponse.getMultiResponse() != null) {
             submissionQuestion.setMultiResponse(questionResponse.getMultiResponse());
-            submissionSection.setSectionStatus(SubmissionSectionStatus.IN_PROGRESS);
+            if (questionResponse.getSectionComplete() != true) {
+                submissionSection.setSectionStatus(SubmissionSectionStatus.IN_PROGRESS);
+            }
         }
 
         if (sectionId.equals(ELIGIBILITY)) {


### PR DESCRIPTION
## Description

[GAP-2096](https://technologyprogramme.atlassian.net/browse/GAP-2096)

Summary of the changes and the related issue. List any dependencies that are required for this change:
Needed to add a way to not reset the section status when editing a Custom Section question from the summary screen

https://github.com/cabinetoffice/gap-find-apply-web/pull/234

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.


[GAP-2096]: https://technologyprogramme.atlassian.net/browse/GAP-2096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ