### PR TITLE
GAP-2095: add GRANT_CLOSED submission status, return submitted date as part of response

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/dto/api/GetSubmissionDto.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/dto/api/GetSubmissionDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -20,6 +21,7 @@ public class GetSubmissionDto {
     private UUID grantSubmissionId;
     private String applicationName;
     private SubmissionStatus submissionStatus;
+    private ZonedDateTime submittedDate;
     @Builder.Default
     private List<GetSectionDto> sections = new ArrayList<>();
 }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/enums/SubmissionStatus.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/enums/SubmissionStatus.java
@@ -1,6 +1,5 @@
 package gov.cabinetoffice.gap.applybackend.enums;
 
 public enum SubmissionStatus {
-    IN_PROGRESS,
-    SUBMITTED
+    IN_PROGRESS, SUBMITTED, GRANT_CLOSED
 }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
@@ -371,6 +371,7 @@ public class SubmissionController {
                 .grantSchemeId(submission.getScheme().getId())
                 .applicationName(submission.getApplicationName())
                 .submissionStatus(submission.getStatus())
+                .submittedDate(submission.getSubmittedDate())
                 .sections(sections)
                 .build();
     }


### PR DESCRIPTION
## Description

[GAP-2095](https://technologyprogramme.atlassian.net/browse/GAP-2095)

Summary of the changes and the related issue. List any dependencies that are required for this change:
Add GRANT_CLOSED status to enum
Return submittedDate as part of submission response for display

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.


[GAP-2095]: https://technologyprogramme.atlassian.net/browse/GAP-2095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ