### PR TITLE
GAP-2360: Add endpoints for middleware

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
@@ -598,5 +598,9 @@ public class SubmissionService {
         final Optional<SubmissionQuestion> eligibilityResponse = getQuestionResponseByQuestionId(submission ,"ELIGIBILITY");
         return eligibilityResponse.map(submissionQuestion -> submissionQuestion.getResponse().equals("Yes")).orElse(false);
     }
+
+    public Optional<Submission> getSubmissionById(final UUID submissionId) {
+        return submissionRepository.findById(submissionId);
+    }
 }
 

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
@@ -6,7 +6,6 @@ import gov.cabinetoffice.gap.applybackend.dto.api.*;
 import gov.cabinetoffice.gap.applybackend.enums.GrantAttachmentStatus;
 import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionOrgType;
 import gov.cabinetoffice.gap.applybackend.enums.SubmissionSectionStatus;
-import gov.cabinetoffice.gap.applybackend.enums.SubmissionStatus;
 import gov.cabinetoffice.gap.applybackend.exception.AttachmentException;
 import gov.cabinetoffice.gap.applybackend.exception.GrantApplicationNotPublishedException;
 import gov.cabinetoffice.gap.applybackend.exception.NotFoundException;
@@ -351,6 +350,18 @@ public class SubmissionController {
     public ResponseEntity<Boolean>  isApplicantEligible(@PathVariable final UUID submissionId) {
         final String applicantId = getUserIdFromSecurityContext();
         return ResponseEntity.ok(submissionService.isApplicantEligible(applicantId, submissionId, "ELIGIBILITY"));
+    }
+
+    @GetMapping("/{submissionId}/application/status")
+    public ResponseEntity<String> schemeStatus(@PathVariable final UUID submissionId) {
+        final String applicantId = getUserIdFromSecurityContext();
+        Optional<Submission> submission = submissionService.getSubmissionById(submissionId);
+        final String submissionApplicant = submission.get().getApplicant().getUserId();
+        if (submission.isPresent() && submissionApplicant.equals(applicantId )) {
+            return ResponseEntity.ok(submission.get().getApplication().getApplicationStatus().toString());
+        } else {
+            return ResponseEntity.notFound().build();
+        }
     }
 
     private GetSubmissionDto buildSubmissionDto(Submission submission) {

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
@@ -353,14 +353,18 @@ public class SubmissionController {
     }
 
     @GetMapping("/{submissionId}/application/status")
-    public ResponseEntity<String> schemeStatus(@PathVariable final UUID submissionId) {
+    public ResponseEntity<String> applicationStatus(@PathVariable final UUID submissionId) {
         final String applicantId = getUserIdFromSecurityContext();
         Optional<Submission> submission = submissionService.getSubmissionById(submissionId);
-        final String submissionApplicant = submission.get().getApplicant().getUserId();
-        if (submission.isPresent() && submissionApplicant.equals(applicantId )) {
-            return ResponseEntity.ok(submission.get().getApplication().getApplicationStatus().toString());
-        } else {
+        if (submission.isEmpty()) {
             return ResponseEntity.notFound().build();
+        }
+
+        String submissionApplicant = submission.get().getApplicant().getUserId();
+        if (submissionApplicant.equals(applicantId)) {
+            return ResponseEntity.ok(submission.get().getApplication().getApplicationStatus().name());
+        } else {
+            return ResponseEntity.status(401).build();
         }
     }
 

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
@@ -1615,6 +1615,15 @@ class SubmissionServiceTest {
             assertThat(result).isFalse();
         }
 
+        @Test
+        void getSubmissionById_ReturnsCorrectSubmission() {
+            Submission submission = Submission.builder().id(SUBMISSION_ID).build();
+            when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
+            Optional<Submission> result = serviceUnderTest.getSubmissionById(SUBMISSION_ID);
+            assertThat(result).isPresent();
+            assertThat(result.get()).isEqualTo(submission);
+        }
+
     }
 
 }

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
@@ -1021,6 +1021,37 @@ class SubmissionControllerTest {
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             assertThat(response.getBody()).isFalse();
         }
+
+        @Test
+        void applicationStatus_ReturnsExpectedResponse() {
+            GrantApplicant applicant = GrantApplicant.builder().userId(APPLICANT_USER_ID).build();
+            GrantApplication application = GrantApplication.builder().applicationStatus(GrantApplicationStatus.REMOVED).build();
+            Submission submission = Submission.builder().id(SUBMISSION_ID).application(application).applicant(applicant).build();
+            when(submissionService.getSubmissionById(SUBMISSION_ID)).thenReturn(Optional.ofNullable(submission));
+            final ResponseEntity<String> response = controllerUnderTest.applicationStatus(SUBMISSION_ID);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isEqualTo("REMOVED");
+        }
+
+        @Test
+        void applicationStatus_ReturnsExpectedResponse_WhenSubmissionNotFound() {
+            when(submissionService.getSubmissionById(SUBMISSION_ID)).thenReturn(Optional.empty());
+            final ResponseEntity<String> response = controllerUnderTest.applicationStatus(SUBMISSION_ID);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        void applicationStatus_ReturnsUnauthorised_WhenIdMismatch() {
+            GrantApplicant applicant = GrantApplicant.builder().userId("testUserId").build();
+            GrantApplication application = GrantApplication.builder().applicationStatus(GrantApplicationStatus.REMOVED).build();
+            Submission submission = Submission.builder().id(SUBMISSION_ID).application(application).applicant(applicant).build();
+            when(submissionService.getSubmissionById(SUBMISSION_ID)).thenReturn(Optional.ofNullable(submission));
+            final ResponseEntity<String> response = controllerUnderTest.applicationStatus(SUBMISSION_ID);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
     }
 
 }


### PR DESCRIPTION
## Description

Adds endpoint which allows the middleware to get the status of an application from the submission id for that application.

Ticket # and link

[GAP-2360](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2360)

Summary of the changes and the related issue. List any dependencies that are required for this change:

This endpoint takes in a submission ID which the middleware provides by parsing the values between /mandatory-questions/{submission-id} and submission/{submission-id}. This lets the middleware reroute the user to the grant-is-closed page when this endpoint returns a REMOVED status half-way through an application

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.


[GAP-2360]: https://technologyprogramme.atlassian.net/browse/GAP-2360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ