### PR TITLE
GAP:2360 Application Status from Mandatory Q UUID

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsController.java
@@ -22,10 +22,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.time.Instant;
-import java.util.Objects;
 import java.util.UUID;
-
-import static gov.cabinetoffice.gap.applybackend.utils.SecurityContextHelper.getUserIdFromSecurityContext;
 
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsController.java
@@ -5,10 +5,7 @@ import gov.cabinetoffice.gap.applybackend.dto.api.JwtPayload;
 import gov.cabinetoffice.gap.applybackend.dto.api.UpdateGrantMandatoryQuestionDto;
 import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionStatus;
 import gov.cabinetoffice.gap.applybackend.mapper.GrantMandatoryQuestionMapper;
-import gov.cabinetoffice.gap.applybackend.model.GrantApplicant;
-import gov.cabinetoffice.gap.applybackend.model.GrantMandatoryQuestions;
-import gov.cabinetoffice.gap.applybackend.model.GrantScheme;
-import gov.cabinetoffice.gap.applybackend.model.Submission;
+import gov.cabinetoffice.gap.applybackend.model.*;
 import gov.cabinetoffice.gap.applybackend.service.GrantApplicantService;
 import gov.cabinetoffice.gap.applybackend.service.GrantMandatoryQuestionService;
 import gov.cabinetoffice.gap.applybackend.service.GrantSchemeService;
@@ -25,7 +22,10 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.UUID;
+
+import static gov.cabinetoffice.gap.applybackend.utils.SecurityContextHelper.getUserIdFromSecurityContext;
 
 @RequiredArgsConstructor
 @RestController
@@ -155,5 +155,15 @@ public class GrantMandatoryQuestionsController {
         log.info("Mandatory question with ID {} has been updated.", grantMandatoryQuestions.getId());
 
         return ResponseEntity.ok(grantMandatoryQuestionService.generateNextPageUrl(url, mandatoryQuestionId, jwtPayload.getSub()));
+    }
+
+    @GetMapping("/{mandatoryQuestionId}/application/status")
+    public ResponseEntity<String> getApplicationStatusByMandatoryQuestionId(@PathVariable final UUID mandatoryQuestionId) {
+        final JwtPayload jwtPayload = (JwtPayload) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        final GrantMandatoryQuestions grantMandatoryQuestions = grantMandatoryQuestionService.getGrantMandatoryQuestionById(mandatoryQuestionId, jwtPayload.getSub());
+        final GrantApplication grantApplication = grantMandatoryQuestions.getGrantScheme().getGrantApplication();
+
+        return ResponseEntity.ok(grantApplication.getApplicationStatus().name());
     }
 }

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsControllerTest.java
@@ -3,6 +3,7 @@ package gov.cabinetoffice.gap.applybackend.web;
 import gov.cabinetoffice.gap.applybackend.dto.api.GetGrantMandatoryQuestionDto;
 import gov.cabinetoffice.gap.applybackend.dto.api.JwtPayload;
 import gov.cabinetoffice.gap.applybackend.dto.api.UpdateGrantMandatoryQuestionDto;
+import gov.cabinetoffice.gap.applybackend.enums.GrantApplicationStatus;
 import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionFundingLocation;
 import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionOrgType;
 import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionStatus;
@@ -347,4 +348,29 @@ class GrantMandatoryQuestionsControllerTest {
 
     }
 
+    @Test
+    void shouldReturnApplicationStatusFromQuestionUUID() {
+
+        final GrantApplication application = GrantApplication.builder()
+                .id(1)
+                .applicationStatus(GrantApplicationStatus.REMOVED)
+                .build();
+        final GrantScheme scheme = GrantScheme.builder()
+                .id(schemeId)
+                .grantApplication(application)
+                .build();
+
+        final GrantMandatoryQuestions mandatoryQuestions = GrantMandatoryQuestions.builder()
+                .id(MANDATORY_QUESTION_ID)
+                .grantScheme(scheme)
+                .createdBy(applicant)
+                .build();
+
+        when(grantMandatoryQuestionService.getGrantMandatoryQuestionById(MANDATORY_QUESTION_ID, jwtPayload.getSub()))
+                .thenReturn(mandatoryQuestions);
+
+        final ResponseEntity<String> methodResponse = controllerUnderTest.getApplicationStatusByMandatoryQuestionId(MANDATORY_QUESTION_ID);
+        assertThat(methodResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(methodResponse.getBody()).isEqualTo("REMOVED");
+    }
 }


### PR DESCRIPTION
## Description

Adds endpoint to check an application's status from the a mandatory questions page's UUID

Ticket # and link

Summary of the changes and the related issue. List any dependencies that are required for this change:

This enables middleware to check if the grant-is-closed between every navigation of mandatory questions

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
