### PR TITLE
Tmi2 667/update endpoint consumed by lambda upload

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SecretAuthService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SecretAuthService.java
@@ -2,6 +2,8 @@ package gov.cabinetoffice.gap.applybackend.service;
 
 import gov.cabinetoffice.gap.applybackend.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -9,6 +11,7 @@ import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SecretAuthService {
 
     @Value("${lambda.secret}")
@@ -25,6 +28,7 @@ public class SecretAuthService {
         if (!Objects.equals(lambdaSecret, authHeader)) {
             throw new UnauthorizedException("Secret key does not match");
         }
+        log.info("Secret key matches");
     }
 
 }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
@@ -2,16 +2,40 @@ package gov.cabinetoffice.gap.applybackend.web;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import gov.cabinetoffice.gap.applybackend.constants.APIConstants;
-import gov.cabinetoffice.gap.applybackend.dto.api.*;
+import gov.cabinetoffice.gap.applybackend.dto.api.CreateQuestionResponseDto;
+import gov.cabinetoffice.gap.applybackend.dto.api.CreateSubmissionResponseDto;
+import gov.cabinetoffice.gap.applybackend.dto.api.GetNavigationParamsDto;
+import gov.cabinetoffice.gap.applybackend.dto.api.GetQuestionDto;
+import gov.cabinetoffice.gap.applybackend.dto.api.GetQuestionNavigationDto;
+import gov.cabinetoffice.gap.applybackend.dto.api.GetSectionDto;
+import gov.cabinetoffice.gap.applybackend.dto.api.GetSubmissionDto;
+import gov.cabinetoffice.gap.applybackend.dto.api.JwtPayload;
+import gov.cabinetoffice.gap.applybackend.dto.api.SubmissionReviewBodyDto;
+import gov.cabinetoffice.gap.applybackend.dto.api.SubmitApplicationDto;
+import gov.cabinetoffice.gap.applybackend.dto.api.UpdateAttachmentDto;
 import gov.cabinetoffice.gap.applybackend.enums.GrantAttachmentStatus;
 import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionOrgType;
 import gov.cabinetoffice.gap.applybackend.enums.SubmissionSectionStatus;
 import gov.cabinetoffice.gap.applybackend.exception.AttachmentException;
 import gov.cabinetoffice.gap.applybackend.exception.GrantApplicationNotPublishedException;
 import gov.cabinetoffice.gap.applybackend.exception.NotFoundException;
-import gov.cabinetoffice.gap.applybackend.model.*;
-import gov.cabinetoffice.gap.applybackend.service.*;
-import gov.cabinetoffice.gap.applybackend.utils.ZipHelper;
+import gov.cabinetoffice.gap.applybackend.model.GrantApplicant;
+import gov.cabinetoffice.gap.applybackend.model.GrantApplication;
+import gov.cabinetoffice.gap.applybackend.model.GrantAttachment;
+import gov.cabinetoffice.gap.applybackend.model.GrantMandatoryQuestions;
+import gov.cabinetoffice.gap.applybackend.model.GrantScheme;
+import gov.cabinetoffice.gap.applybackend.model.Submission;
+import gov.cabinetoffice.gap.applybackend.model.SubmissionQuestion;
+import gov.cabinetoffice.gap.applybackend.model.SubmissionSection;
+import gov.cabinetoffice.gap.applybackend.service.AttachmentService;
+import gov.cabinetoffice.gap.applybackend.service.GrantApplicantService;
+import gov.cabinetoffice.gap.applybackend.service.GrantApplicationService;
+import gov.cabinetoffice.gap.applybackend.service.GrantAttachmentService;
+import gov.cabinetoffice.gap.applybackend.service.GrantMandatoryQuestionService;
+import gov.cabinetoffice.gap.applybackend.service.SecretAuthService;
+import gov.cabinetoffice.gap.applybackend.service.SpotlightService;
+import gov.cabinetoffice.gap.applybackend.service.SubmissionService;
+import gov.cabinetoffice.gap.applybackend.service.ZipService;
 import gov.cabinetoffice.gap.eventservice.enums.EventType;
 import gov.cabinetoffice.gap.eventservice.exception.InvalidEventException;
 import gov.cabinetoffice.gap.eventservice.service.EventLogService;
@@ -26,7 +50,16 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
@@ -34,8 +67,13 @@ import javax.validation.Valid;
 import java.io.ByteArrayOutputStream;
 import java.time.Clock;
 import java.time.Instant;
-import java.util.*;
-import java.util.zip.ZipOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 
 import static gov.cabinetoffice.gap.applybackend.utils.SecurityContextHelper.getJwtIdFromSecurityContext;
 import static gov.cabinetoffice.gap.applybackend.utils.SecurityContextHelper.getUserIdFromSecurityContext;
@@ -47,6 +85,7 @@ import static gov.cabinetoffice.gap.applybackend.utils.SecurityContextHelper.get
 @RestController
 public class SubmissionController {
 
+    private static final String SPECIAL_CHARACTER_REGEX = "[^a-zA-Z0-9()_,.-]";
     private final SubmissionService submissionService;
     private final GrantApplicantService grantApplicantService;
     private final GrantAttachmentService grantAttachmentService;
@@ -54,14 +93,11 @@ public class SubmissionController {
     private final SpotlightService spotlightService;
     private final GrantMandatoryQuestionService mandatoryQuestionService;
     private final ZipService zipService;
-
     private final SecretAuthService secretAuthService;
     private final AttachmentService attachmentService;
     private final EventLogService eventLogService;
     private final Logger logger = LoggerFactory.getLogger(SubmissionController.class);
     private final Clock clock;
-
-    private static final String SPECIAL_CHARACTER_REGEX = "[^a-zA-Z0-9()_,.-]";
 
     @GetMapping
     public ResponseEntity<List<GetSubmissionDto>> getSubmissions() {
@@ -234,28 +270,37 @@ public class SubmissionController {
         return ResponseEntity.ok(submissionResponseDto);
     }
 
+    //this endpoint is consumed by the lambda-upload
     @PutMapping("/{submissionId}/question/{questionId}/attachment/scanresult")
     public ResponseEntity<String> updateAttachment(
             @PathVariable final UUID submissionId,
             @PathVariable final String questionId,
             @RequestBody final UpdateAttachmentDto updateDetails,
             @RequestHeader(HttpHeaders.AUTHORIZATION) final String authHeader) {
-        final String applicantId = getUserIdFromSecurityContext();
+        log.info("Lambda-upload is updating attachment for submissionId: {}, questionId: {} based on the scan result", submissionId, questionId);
 
         secretAuthService.authenticateSecret(authHeader);
 
-        Submission submission = submissionService.getSubmissionFromDatabaseBySubmissionId(applicantId, submissionId);
-        GrantAttachment attachment = grantAttachmentService.getAttachmentBySubmissionAndQuestion(submission, questionId);
+        final Submission submission = submissionService.getSubmissionById(submissionId);
+        log.info("Submission found for submissionId: {}", submissionId);
+
+        final GrantAttachment attachment = grantAttachmentService.getAttachmentBySubmissionAndQuestion(submission, questionId);
+        log.info("Attachment with id {} found for submissionId: {}, questionId: {}", attachment.getId(), submissionId, questionId);
+        log.info(" The file after scan check is clean : {}", updateDetails.getIsClean());
 
         attachment.setLastUpdated(Instant.now(clock));
         attachment.setLocation(updateDetails.getUri());
+
         if (Boolean.TRUE.equals(updateDetails.getIsClean())) {
             attachment.setStatus(GrantAttachmentStatus.AVAILABLE);
+            log.info("Attachment for submissionId: {}, questionId: {} status is set to AVAILABLE", submissionId, questionId);
         } else {
             attachment.setStatus(GrantAttachmentStatus.QUARANTINED);
+            log.info("Attachment for submissionId: {}, questionId: {} status is set to QUARANTINED", submissionId, questionId);
         }
 
         grantAttachmentService.save(attachment);
+        log.info("Attachment for submissionId: {}, questionId: {} is updated", submissionId, questionId);
 
         logSubmissionEvent(EventType.SUBMISSION_UPDATED, submissionId.toString());
 
@@ -363,7 +408,7 @@ public class SubmissionController {
         final Submission submission = submissionService.getSubmissionById(submissionId);
 
         try (OdfTextDocument odt = submissionService.getSubmissionExport(submission, userEmail, userSub);
-             ByteArrayOutputStream zip = zipService.createSubmissionZip(submission, odt)){
+             ByteArrayOutputStream zip = zipService.createSubmissionZip(submission, odt)) {
 
             ByteArrayResource zipResource = zipService.byteArrayOutputStreamToResource(zip);
 
@@ -372,15 +417,15 @@ public class SubmissionController {
             headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE);
 
             return ResponseEntity.ok().headers(headers).contentLength(zipResource.contentLength())
-                        .contentType(MediaType.APPLICATION_OCTET_STREAM).body(zipResource);
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM).body(zipResource);
         } catch (Exception e) {
             log.error("Could not generate ZIP. Exception: ", e);
             throw new RuntimeException(e);
         }
     }
 
-        @GetMapping("/{submissionId}/isApplicantEligible")
-    public ResponseEntity<Boolean>  isApplicantEligible(@PathVariable final UUID submissionId) {
+    @GetMapping("/{submissionId}/isApplicantEligible")
+    public ResponseEntity<Boolean> isApplicantEligible(@PathVariable final UUID submissionId) {
         final String applicantId = getUserIdFromSecurityContext();
         return ResponseEntity.ok(submissionService.isApplicantEligible(applicantId, submissionId));
     }

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
@@ -1076,9 +1076,7 @@ class SubmissionControllerTest {
                 when(zipService.createSubmissionZip(any(), any()))
                         .thenThrow(new IOException("Error creating zip file"));
 
-                RuntimeException runtimeException = assertThrows(RuntimeException.class, () -> {
-                    controllerUnderTest.exportSingleSubmission(submissionId, mockRequest);
-                });
+                RuntimeException runtimeException = assertThrows(RuntimeException.class, () -> controllerUnderTest.exportSingleSubmission(submissionId, mockRequest));
 
                 assertInstanceOf(IOException.class, runtimeException.getCause());
                 verify(submissionService, times(1)).getSubmissionExport(any(), any(), any());


### PR DESCRIPTION
## Description

[Ticket # and link](https://technologyprogramme.atlassian.net/browse/TMI2-667)
an endpoint which is consumed by the lambda-upload was getting the applicant Id from the Security context and then passing it to a service method to filter result based on the applicant Id.

since this endpoint is whitelisted, as we check the authenticity of the call from the lambda in other ways, the Security context is never built, which would lead to this endpoint always throwing an error at the service method.

This pr fixes the issue.

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.

