### PR TITLE
TMI2-697: handle draft adverts

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/repository/GrantApplicationRepository.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/repository/GrantApplicationRepository.java
@@ -1,6 +1,7 @@
 package gov.cabinetoffice.gap.applybackend.repository;
 
 
+import gov.cabinetoffice.gap.applybackend.enums.GrantApplicationStatus;
 import gov.cabinetoffice.gap.applybackend.model.GrantApplication;
 import gov.cabinetoffice.gap.applybackend.model.GrantScheme;
 import org.jetbrains.annotations.NotNull;
@@ -15,6 +16,7 @@ public interface GrantApplicationRepository extends JpaRepository<GrantApplicati
 
     Optional<GrantApplication> findByGrantScheme(GrantScheme grantScheme);
 
+    Optional<GrantApplication> findByGrantSchemeAndApplicationStatus(GrantScheme grantScheme, GrantApplicationStatus applicationStatus);
 
     @NotNull
     @EntityGraph(attributePaths = {"grantScheme"})

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantAdvertService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantAdvertService.java
@@ -54,7 +54,7 @@ public class GrantAdvertService {
     }
 
     public GetGrantAdvertDto generateGetGrantAdvertDto(GrantAdvert advert, GetGrantMandatoryQuestionDto mandatoryQuestions) {
-        final boolean isInternal = grantApplicationService.doesSchemeHaveApplication(advert.getScheme());
+        final boolean isInternal = grantApplicationService.doesSchemeHaveAPublishedApplication(advert.getScheme());
         final Integer grantApplicationId = grantApplicationService.getGrantApplicationId(advert.getScheme());
 
         return GetGrantAdvertDto.builder()

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantApplicationService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantApplicationService.java
@@ -31,8 +31,8 @@ public class GrantApplicationService {
         return getGrantApplicationById(applicationId).getApplicationStatus().equals(GrantApplicationStatus.PUBLISHED);
     }
 
-    public boolean doesSchemeHaveApplication(final GrantScheme grantScheme) {
-        return grantApplicationRepository.findByGrantScheme(grantScheme).isPresent();
+    public boolean doesSchemeHaveAPublishedApplication(final GrantScheme grantScheme) {
+        return grantApplicationRepository.findByGrantSchemeAndApplicationStatus(grantScheme, GrantApplicationStatus.PUBLISHED).isPresent();
     }
 
     public Integer getGrantApplicationId(final GrantScheme grantScheme) {

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
@@ -134,9 +134,9 @@ public class GrantMandatoryQuestionService {
     }
 
     public void addMandatoryQuestionsToSubmissionObject(final GrantMandatoryQuestions mandatoryQuestions) {
-        if (mandatoryQuestions.getSubmission() != null &&
-                mandatoryQuestions.getSubmission().getVersion() > 1) {
-            final Submission submission = mandatoryQuestions.getSubmission();
+        final Submission submission = mandatoryQuestions.getSubmission();
+
+        if (submission != null && submission.getScheme().getVersion() > 1) { // TODO: should we check scheme version instead of submission version?
 
             log.info("Adding mandatory question responses to submission " + submission.getId());
 

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
@@ -136,7 +136,7 @@ public class GrantMandatoryQuestionService {
     public void addMandatoryQuestionsToSubmissionObject(final GrantMandatoryQuestions mandatoryQuestions) {
         final Submission submission = mandatoryQuestions.getSubmission();
 
-        if (submission != null && submission.getScheme().getVersion() > 1) { // TODO: should we check scheme version instead of submission version?
+        if (submission != null && submission.getScheme().getVersion() > 1) {
 
             log.info("Adding mandatory question responses to submission " + submission.getId());
 

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantAdvertController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantAdvertController.java
@@ -130,7 +130,7 @@ public class GrantAdvertController {
     @Operation(summary = "Get advert scheme version and whether it is an internal application")
     public ResponseEntity<GetGrantAdvertSummaryDto> getAdvertSchemeVersion(@PathVariable final String advertSlug) {
         GrantAdvert advert = grantAdvertService.getAdvertByContentfulSlug(advertSlug);
-        boolean isInternalApplication = grantApplicationService.doesSchemeHaveApplication(advert.getScheme());
+        boolean isInternalApplication = grantApplicationService.doesSchemeHaveAPublishedApplication(advert.getScheme());
 
         GetGrantAdvertSummaryDto advertSummary = GetGrantAdvertSummaryDto.builder()
                 .schemeVersion(advert.getScheme().getVersion())

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantSchemeController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantSchemeController.java
@@ -1,6 +1,7 @@
 package gov.cabinetoffice.gap.applybackend.web;
 
 import gov.cabinetoffice.gap.applybackend.dto.api.*;
+import gov.cabinetoffice.gap.applybackend.enums.GrantAdvertStatus;
 import gov.cabinetoffice.gap.applybackend.mapper.GrantSchemeMapper;
 import gov.cabinetoffice.gap.applybackend.model.GrantScheme;
 import gov.cabinetoffice.gap.applybackend.service.GrantAdvertService;
@@ -41,7 +42,9 @@ public class GrantSchemeController {
         final GetGrantSchemeDto grantSchemeDto = new GetGrantSchemeDto(grantScheme);
         final GetGrantApplicationDto grantApplicationDto = grantSchemeMapper.grantSchemeToGetGrantApplicationDto(grantScheme);
         final List<GetGrantAdvertDto> grantAdvertDtos = grantScheme.getGrantAdverts().stream()
-                .map(grantAdvert -> grantAdvertService.grantAdvertToDto(grantAdvert, jwtPayload.getSub(), grantSchemeId))
+                .map(grantAdvert ->
+                        grantAdvert.getStatus().equals(GrantAdvertStatus.PUBLISHED) ?
+                        grantAdvertService.grantAdvertToDto(grantAdvert, jwtPayload.getSub(), grantSchemeId) : null)
                 .toList();
 
         final GetGrantSchemeWithApplicationAndAdverts getGrantSchemeWithApplicationAndAdverts = GetGrantSchemeWithApplicationAndAdverts.builder()

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantSchemeController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantSchemeController.java
@@ -42,9 +42,8 @@ public class GrantSchemeController {
         final GetGrantSchemeDto grantSchemeDto = new GetGrantSchemeDto(grantScheme);
         final GetGrantApplicationDto grantApplicationDto = grantSchemeMapper.grantSchemeToGetGrantApplicationDto(grantScheme);
         final List<GetGrantAdvertDto> grantAdvertDtos = grantScheme.getGrantAdverts().stream()
-                .map(grantAdvert ->
-                        grantAdvert.getStatus().equals(GrantAdvertStatus.PUBLISHED) ?
-                        grantAdvertService.grantAdvertToDto(grantAdvert, jwtPayload.getSub(), grantSchemeId) : null)
+                .filter(grantAdvert -> grantAdvert.getStatus().equals(GrantAdvertStatus.PUBLISHED))
+                .map(grantAdvert -> grantAdvertService.grantAdvertToDto(grantAdvert, jwtPayload.getSub(), grantSchemeId))
                 .toList();
 
         final GetGrantSchemeWithApplicationAndAdverts getGrantSchemeWithApplicationAndAdverts = GetGrantSchemeWithApplicationAndAdverts.builder()

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantAdvertServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantAdvertServiceTest.java
@@ -140,7 +140,7 @@ class GrantAdvertServiceTest {
                     .build();
             final GetGrantMandatoryQuestionDto mandatoryQuestionDto = GetGrantMandatoryQuestionDto.builder().build();
 
-            when(grantApplicationService.doesSchemeHaveApplication(scheme)).thenReturn(true);
+            when(grantApplicationService.doesSchemeHaveAPublishedApplication(scheme)).thenReturn(true);
             when(grantApplicationService.getGrantApplicationId(scheme)).thenReturn(1);
 
             final GetGrantAdvertDto methodResponse = grantAdvertService.generateGetGrantAdvertDto(advert, mandatoryQuestionDto);
@@ -169,7 +169,7 @@ class GrantAdvertServiceTest {
                     .build();
             final GetGrantMandatoryQuestionDto mandatoryQuestionDto = GetGrantMandatoryQuestionDto.builder().build();
 
-            when(grantApplicationService.doesSchemeHaveApplication(scheme)).thenReturn(true);
+            when(grantApplicationService.doesSchemeHaveAPublishedApplication(scheme)).thenReturn(true);
             when(grantApplicationService.getGrantApplicationId(scheme)).thenReturn(1);
 
             final GetGrantAdvertDto methodResponse = grantAdvertService.generateGetGrantAdvertDto(advert, mandatoryQuestionDto);
@@ -198,7 +198,7 @@ class GrantAdvertServiceTest {
                     .build();
             final GetGrantMandatoryQuestionDto mandatoryQuestionDto = GetGrantMandatoryQuestionDto.builder().build();
 
-            when(grantApplicationService.doesSchemeHaveApplication(scheme)).thenReturn(false);
+            when(grantApplicationService.doesSchemeHaveAPublishedApplication(scheme)).thenReturn(false);
             when(grantApplicationService.getGrantApplicationId(scheme)).thenReturn(null);
 
             final GetGrantAdvertDto methodResponse = grantAdvertService.generateGetGrantAdvertDto(advert, mandatoryQuestionDto);
@@ -227,7 +227,7 @@ class GrantAdvertServiceTest {
                     .build();
             final GetGrantMandatoryQuestionDto mandatoryQuestionDto = GetGrantMandatoryQuestionDto.builder().build();
 
-            when(grantApplicationService.doesSchemeHaveApplication(scheme)).thenReturn(false);
+            when(grantApplicationService.doesSchemeHaveAPublishedApplication(scheme)).thenReturn(false);
             when(grantApplicationService.getGrantApplicationId(scheme)).thenReturn(null);
 
             final GetGrantAdvertDto methodResponse = grantAdvertService.generateGetGrantAdvertDto(advert, mandatoryQuestionDto);
@@ -256,7 +256,7 @@ class GrantAdvertServiceTest {
                     .build();
             final GetGrantMandatoryQuestionDto mandatoryQuestionDto = GetGrantMandatoryQuestionDto.builder().build();
 
-            when(grantApplicationService.doesSchemeHaveApplication(scheme)).thenReturn(false);
+            when(grantApplicationService.doesSchemeHaveAPublishedApplication(scheme)).thenReturn(false);
             when(grantApplicationService.getGrantApplicationId(scheme)).thenReturn(null);
 
             final GetGrantAdvertDto methodResponse = grantAdvertService.generateGetGrantAdvertDto(advert, mandatoryQuestionDto);
@@ -285,7 +285,7 @@ class GrantAdvertServiceTest {
                     .build();
             final GetGrantMandatoryQuestionDto mandatoryQuestionDto = GetGrantMandatoryQuestionDto.builder().build();
 
-            when(grantApplicationService.doesSchemeHaveApplication(scheme)).thenReturn(false);
+            when(grantApplicationService.doesSchemeHaveAPublishedApplication(scheme)).thenReturn(false);
             when(grantApplicationService.getGrantApplicationId(scheme)).thenReturn(null);
 
             final GetGrantAdvertDto methodResponse = grantAdvertService.generateGetGrantAdvertDto(advert, mandatoryQuestionDto);
@@ -314,7 +314,7 @@ class GrantAdvertServiceTest {
                     .build();
             final GetGrantMandatoryQuestionDto mandatoryQuestionDto = GetGrantMandatoryQuestionDto.builder().build();
 
-            when(grantApplicationService.doesSchemeHaveApplication(scheme)).thenReturn(false);
+            when(grantApplicationService.doesSchemeHaveAPublishedApplication(scheme)).thenReturn(false);
             when(grantApplicationService.getGrantApplicationId(scheme)).thenReturn(null);
 
             final GetGrantAdvertDto methodResponse = grantAdvertService.generateGetGrantAdvertDto(advert, mandatoryQuestionDto);

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantApplicationServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantApplicationServiceTest.java
@@ -98,14 +98,17 @@ class GrantApplicationServiceTest {
     @Test
     void doesSchemeHaveApplication__True() {
         final GrantScheme scheme = GrantScheme.builder().id(1).build();
-        final GrantApplication application = GrantApplication.builder().grantScheme(scheme)
+        final GrantApplication application = GrantApplication.builder()
+                .grantScheme(scheme)
+                .applicationStatus(GrantApplicationStatus.PUBLISHED)
                 .build();
 
-        when(grantApplicationRepository.findByGrantScheme(scheme)).thenReturn(Optional.of(application));
+        when(grantApplicationRepository.findByGrantSchemeAndApplicationStatus(scheme, GrantApplicationStatus.PUBLISHED))
+                .thenReturn(Optional.of(application));
 
-        final boolean response = serviceUnderTest.doesSchemeHaveApplication(scheme);
+        final boolean response = serviceUnderTest.doesSchemeHaveAPublishedApplication(scheme);
 
-        verify(grantApplicationRepository).findByGrantScheme(scheme);
+        verify(grantApplicationRepository).findByGrantSchemeAndApplicationStatus(scheme, GrantApplicationStatus.PUBLISHED);
         assertTrue(response);
     }
 
@@ -113,11 +116,11 @@ class GrantApplicationServiceTest {
     void doesSchemeHaveApplication__False() {
         final GrantScheme scheme = GrantScheme.builder().id(1).build();
 
-        when(grantApplicationRepository.findByGrantScheme(scheme)).thenReturn(Optional.empty());
+        when(grantApplicationRepository.findByGrantSchemeAndApplicationStatus(scheme, GrantApplicationStatus.PUBLISHED)).thenReturn(Optional.empty());
 
-        final boolean response = serviceUnderTest.doesSchemeHaveApplication(scheme);
+        final boolean response = serviceUnderTest.doesSchemeHaveAPublishedApplication(scheme);
 
-        verify(grantApplicationRepository).findByGrantScheme(scheme);
+        verify(grantApplicationRepository).findByGrantSchemeAndApplicationStatus(scheme, GrantApplicationStatus.PUBLISHED);
         assertFalse(response);
     }
 

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
@@ -550,6 +550,7 @@ class GrantMandatoryQuestionServiceTest {
     @Nested
     class addMandatoryQuestionsToSubmissionObject {
         //TODO I think we could maybe write more thorough tests for this method but these should be OK for now
+        final GrantScheme grantScheme = GrantScheme.builder().version(2).build();
 
         @Test
         void doesNothing_IfSubmissionIsNull() {
@@ -567,10 +568,11 @@ class GrantMandatoryQuestionServiceTest {
         }
 
         @Test
-        void doesNothing_IfSubmissionIsVersionOne() {
-
+        void doesNothing_IfSchemeIsVersionOne() {
+            final GrantScheme scheme = GrantScheme.builder().version(1).build();
             final Submission submission = Submission.builder()
                     .version(1)
+                    .scheme(scheme)
                     .build();
 
             final GrantMandatoryQuestions mandatoryQuestions = GrantMandatoryQuestions.builder()
@@ -594,6 +596,7 @@ class GrantMandatoryQuestionServiceTest {
             final Submission submission = Submission.builder()
                     .definition(definition)
                     .version(2)
+                    .scheme(grantScheme)
                     .build();
 
             final GrantMandatoryQuestions mandatoryQuestions = GrantMandatoryQuestions.builder()
@@ -619,6 +622,7 @@ class GrantMandatoryQuestionServiceTest {
             final Submission submission = Submission.builder()
                     .definition(definition)
                     .version(2)
+                    .scheme(grantScheme)
                     .build();
 
             final GrantMandatoryQuestions mandatoryQuestions = GrantMandatoryQuestions.builder()
@@ -652,6 +656,7 @@ class GrantMandatoryQuestionServiceTest {
             final Submission submission = Submission.builder()
                     .definition(definition)
                     .version(2)
+                    .scheme(grantScheme)
                     .build();
 
             final GrantMandatoryQuestions mandatoryQuestions = GrantMandatoryQuestions.builder()

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantAdvertControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantAdvertControllerTest.java
@@ -252,7 +252,7 @@ class GrantAdvertControllerTest {
 
             when(grantAdvertService.getAdvertByContentfulSlug(mockInternalV1Advert.getContentfulSlug()))
                     .thenReturn(mockInternalV1Advert);
-            when(grantApplicationService.doesSchemeHaveApplication(mockInternalV1Advert.getScheme()))
+            when(grantApplicationService.doesSchemeHaveAPublishedApplication(mockInternalV1Advert.getScheme()))
                     .thenReturn(true);
 
             ResponseEntity<GetGrantAdvertSummaryDto> response = grantAdvertController.getAdvertSchemeVersion(mockInternalV1Advert.getContentfulSlug());
@@ -274,7 +274,7 @@ class GrantAdvertControllerTest {
 
             when(grantAdvertService.getAdvertByContentfulSlug(mockExternalV1Advert.getContentfulSlug()))
                     .thenReturn(mockExternalV1Advert);
-            when(grantApplicationService.doesSchemeHaveApplication(mockExternalV1Advert.getScheme()))
+            when(grantApplicationService.doesSchemeHaveAPublishedApplication(mockExternalV1Advert.getScheme()))
                     .thenReturn(false);
 
             ResponseEntity<GetGrantAdvertSummaryDto> response = grantAdvertController.getAdvertSchemeVersion(mockExternalV1Advert.getContentfulSlug());
@@ -296,7 +296,7 @@ class GrantAdvertControllerTest {
 
             when(grantAdvertService.getAdvertByContentfulSlug(mockInternalV2Advert.getContentfulSlug()))
                     .thenReturn(mockInternalV2Advert);
-            when(grantApplicationService.doesSchemeHaveApplication(mockInternalV2Advert.getScheme()))
+            when(grantApplicationService.doesSchemeHaveAPublishedApplication(mockInternalV2Advert.getScheme()))
                     .thenReturn(true);
 
             ResponseEntity<GetGrantAdvertSummaryDto> response = grantAdvertController.getAdvertSchemeVersion(mockInternalV2Advert.getContentfulSlug());
@@ -318,7 +318,7 @@ class GrantAdvertControllerTest {
 
             when(grantAdvertService.getAdvertByContentfulSlug(mockExternalV2Advert.getContentfulSlug()))
                     .thenReturn(mockExternalV2Advert);
-            when(grantApplicationService.doesSchemeHaveApplication(mockExternalV2Advert.getScheme()))
+            when(grantApplicationService.doesSchemeHaveAPublishedApplication(mockExternalV2Advert.getScheme()))
                     .thenReturn(false);
 
             ResponseEntity<GetGrantAdvertSummaryDto> response = grantAdvertController.getAdvertSchemeVersion(mockExternalV2Advert.getContentfulSlug());

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantSchemeControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantSchemeControllerTest.java
@@ -3,7 +3,9 @@ package gov.cabinetoffice.gap.applybackend.web;
 import gov.cabinetoffice.gap.applybackend.dto.api.GetGrantSchemeDto;
 import gov.cabinetoffice.gap.applybackend.dto.api.GetGrantSchemeWithApplicationAndAdverts;
 import gov.cabinetoffice.gap.applybackend.dto.api.JwtPayload;
+import gov.cabinetoffice.gap.applybackend.enums.GrantAdvertStatus;
 import gov.cabinetoffice.gap.applybackend.mapper.GrantSchemeMapper;
+import gov.cabinetoffice.gap.applybackend.model.GrantAdvert;
 import gov.cabinetoffice.gap.applybackend.model.GrantApplication;
 import gov.cabinetoffice.gap.applybackend.model.GrantScheme;
 import gov.cabinetoffice.gap.applybackend.service.GrantSchemeService;
@@ -78,6 +80,36 @@ class GrantSchemeControllerTest {
         assertEquals(GetGrantSchemeWithApplicationAndAdverts.builder()
                 .grantScheme(getGrantSchemeDto)
                 .grantAdverts(Collections.emptyList())
+                .grantApplication(null)
+                .build(), response.getBody());
+    }
+
+    @Test
+    void getGrantSchemeById_ReturnsTheCorrectGrantSchemeWithNoAdverts() {
+        final GrantAdvert grantAdvert = GrantAdvert.builder().status(GrantAdvertStatus.DRAFT).build();
+        final GrantScheme grantScheme = GrantScheme.builder()
+                .id(SCHEME_ID)
+                .funderId(1)
+                .version(1)
+                .lastUpdated(Instant.now())
+                .lastUpdatedBy(1)
+                .ggisIdentifier("SCH-000003589")
+                .name("scheme_name")
+                .email("contact@contact.com")
+                .grantAdverts(Collections.singletonList(grantAdvert))
+                .grantApplication(GrantApplication.builder().build())
+                .build();
+        final GetGrantSchemeDto getGrantSchemeDto = new GetGrantSchemeDto(grantScheme);
+
+        when(grantSchemeService.getSchemeByIdWithApplicationAndAdverts(SCHEME_ID)).thenReturn(grantScheme);
+
+        ResponseEntity<GetGrantSchemeWithApplicationAndAdverts> response = controllerUnderTest.getGrantSchemeById(SCHEME_ID);
+
+        verify(grantSchemeService).getSchemeByIdWithApplicationAndAdverts(SCHEME_ID);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(GetGrantSchemeWithApplicationAndAdverts.builder()
+                .grantScheme(getGrantSchemeDto)
+                .grantAdverts(Collections.singletonList(null))
                 .grantApplication(null)
                 .build(), response.getBody());
     }

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantSchemeControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantSchemeControllerTest.java
@@ -109,7 +109,7 @@ class GrantSchemeControllerTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(GetGrantSchemeWithApplicationAndAdverts.builder()
                 .grantScheme(getGrantSchemeDto)
-                .grantAdverts(Collections.singletonList(null))
+                .grantAdverts(Collections.emptyList())
                 .grantApplication(null)
                 .build(), response.getBody());
     }


### PR DESCRIPTION
## Description
It checks the scheme version instead of the submission version inside `addMandatoryQuestionsToSubmissionObject` and 
only adds grant adverts to `grantAdvertDtos` list if it has a status of PUBLISHED

Ticket # and link
TMI2-697: https://technologyprogramme.atlassian.net/browse/TMI2-697

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
