### PR TITLE
GAP-1596: properly sort error messages from back end

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/controlleradvice/ControllerExceptionHandler.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/controlleradvice/ControllerExceptionHandler.java
@@ -1,13 +1,10 @@
 package gov.cabinetoffice.gap.applybackend.web.controlleradvice;
 
-import gov.cabinetoffice.gap.applybackend.exception.AttachmentException;
-import gov.cabinetoffice.gap.applybackend.exception.GrantApplicationNotPublishedException;
-import gov.cabinetoffice.gap.applybackend.exception.NotFoundException;
-import gov.cabinetoffice.gap.applybackend.exception.SubmissionAlreadyCreatedException;
-import gov.cabinetoffice.gap.applybackend.exception.SubmissionNotReadyException;
+import gov.cabinetoffice.gap.applybackend.exception.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -20,11 +17,14 @@ import org.springframework.web.context.request.WebRequest;
 import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class ControllerExceptionHandler {
+    public static final List<String> ADDRESS_FIELDS = List.of("addressLine1", "addressLine2", "city", "county", "postcode");
 
     private final Clock clock;
 
@@ -48,22 +48,108 @@ public class ControllerExceptionHandler {
     public ErrorResponseBody handleValidationExceptions(
             MethodArgumentNotValidException ex) {
         log.error("MethodArgumentNotValidException thrown: ", ex.getStackTrace());
+        final List<Error> errors = ex.getAllErrors()
+                .stream()
+                .map(e -> {
+                    final String fieldName = e instanceof FieldError fieldError ? fieldError.getField() : e.getObjectName();
+                    return Error.builder()
+                            .fieldName(fieldName)
+                            .errorMessage(e.getDefaultMessage())
+                            .build();
+                })
+                .toList();
+
         return ErrorResponseBody.builder()
                 .responseAccepted(Boolean.FALSE)
                 .message("Validation failure")
-                .errors(ex.getAllErrors()
-                        .stream()
-                        .map(e -> {
-                            final String fieldName = e instanceof FieldError fieldError ? fieldError.getField() : e.getObjectName();
-                            return Error.builder()
-                                    .fieldName(fieldName)
-                                    .errorMessage(e.getDefaultMessage())
-                                    .build();
-                        })
-                        .toList()
-                )
+                .errors(sortFieldErrors(errors))
                 .invalidData(ex.getBindingResult().getTarget())
                 .build();
+    }
+
+    private List<Error> sortFieldErrors(List<Error> errors) {
+        if (errors.stream().anyMatch(error -> error.getFieldName().contains("multiResponse"))) {
+            return sortMultiResponseErrors(errors);
+        } else if (errors.stream().anyMatch(error -> ADDRESS_FIELDS.contains(error.getFieldName()))) {
+            return sortAddressResponseErrors(errors);
+        }
+
+        return errors;
+    }
+
+    /**
+     * Sorts multi response errors in ascending numeric order.
+     * For example. multiResponse[0] will always appear above multiResponse[1] in the list.
+     *
+     * @param errors
+     * @return sorted list of error fields
+     */
+    @NotNull
+    private List<Error> sortMultiResponseErrors(List<Error> errors) {
+        return errors.stream()
+                .sorted((a, b) -> {
+                    int multiResponseField = getIntegerFromFieldName(a);
+                    int multiResponseField2 = getIntegerFromFieldName(b);
+
+                    return multiResponseField - multiResponseField2;
+                })
+                .toList();
+    }
+
+    /**
+     * Sorts address response errors in order of how the fields appear on the form
+     *
+     * - addressLine1
+     * - addressLine2
+     * - city
+     * - county
+     * - postcode
+     *
+     * @param errors
+     * @return
+     */
+    private List<Error> sortAddressResponseErrors(List<Error> errors) {
+        return errors.stream()
+                .sorted((a, b) -> {
+                    int multiResponseField1 = getIntFromAddressField(a);
+                    int multiResponseField2 = getIntFromAddressField(b);
+
+                    return multiResponseField1 - multiResponseField2;
+                })
+                .toList();
+    }
+
+    private int getIntFromAddressField(Error fieldError) {
+        switch (fieldError.getFieldName()) {
+            case "addressLine1":
+                return 1;
+            case "addressLine2":
+                return 2;
+            case "city":
+                return 3;
+            case "county":
+                return 4;
+            case "postcode":
+                return 5;
+            default:
+                return 0;
+        }
+    }
+
+    private int getIntegerFromFieldName(Error fieldError) {
+        final Pattern pattern = Pattern.compile("-?\\d+");
+        final Matcher matcher = pattern.matcher(fieldError.getFieldName());
+
+        while (matcher.find()) {
+            try {
+                return Integer.parseInt(matcher.group());
+            } catch (NumberFormatException e) {
+                log.error("can't parse string as integer", e);
+                return 0;
+            }
+        }
+
+        return 0;
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/controlleradvice/ControllerExceptionHandlerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/controlleradvice/ControllerExceptionHandlerTest.java
@@ -115,6 +115,140 @@ class ControllerExceptionHandlerTest {
         assertThat(response).isEqualTo(body);
     }
 
+    @Test
+    void handleValidationExceptions_HandlesMultiResponse_AndSortsProperly() {
+
+        final String multiResponseErrorMessage1 = "You must enter a response";
+        final String multiResponseErrorField1 = "multiResponse[0]";
+
+        final String multiResponseErrorMessage2 = "You must enter a response";
+        final String multiResponseErrorField2 = "multiResponse[3]";
+
+        final String multiResponseErrorMessage3 = "You must enter a response";
+        final String multiResponseErrorField3 = "multiResponse[4]";
+
+        // set up validation failure
+        final ObjectError fieldError1 = new FieldError("question", multiResponseErrorField1, multiResponseErrorMessage1);
+        final ObjectError fieldError2 = new FieldError("question", multiResponseErrorField2, multiResponseErrorMessage2);
+        final ObjectError fieldError3 = new FieldError("question", multiResponseErrorField3, multiResponseErrorMessage3);
+
+        final BindingResult result = mock(BindingResult.class);
+        when(result.getAllErrors())
+                .thenReturn(
+                        List.of(fieldError2, fieldError1, fieldError3)
+                );
+
+        // exception thrown by Spring when validation failure occurs
+        final MethodParameter parameter = mock(MethodParameter.class);
+        final MethodArgumentNotValidException ex = new MethodArgumentNotValidException(parameter, result);
+
+        // make the web request
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/some-uri");
+        request.setRemoteAddr("https://some-domain.com");
+
+        // Build the expected error message
+        final Error expectedFieldError1 = Error.builder()
+                .fieldName(multiResponseErrorField1)
+                .errorMessage(multiResponseErrorMessage1)
+                .build();
+        final Error expectedFieldError2 = Error.builder()
+                .fieldName(multiResponseErrorField2)
+                .errorMessage(multiResponseErrorMessage2)
+                .build();
+        final Error expectedFieldError3 = Error.builder()
+                .fieldName(multiResponseErrorField3)
+                .errorMessage(multiResponseErrorMessage3)
+                .build();
+        final ErrorResponseBody body = ErrorResponseBody.builder()
+                .responseAccepted(Boolean.FALSE)
+                .message("Validation failure")
+                .errors(List.of(expectedFieldError1, expectedFieldError2, expectedFieldError3))
+                .build();
+
+        ErrorResponseBody response = exceptionHandlerUnderTest.handleValidationExceptions(ex);
+
+        assertThat(response).isEqualTo(body);
+    }
+
+    @Test
+    void handleValidationExceptions_HandlesAddressResponse_AndSortsProperly() {
+
+        final String addressResponseErrorMessage1 = "You must enter a response";
+        final String addressResponseErrorField1 = "addressLine1";
+
+        final String addressResponseErrorMessage2 = "response must not be a ghost";
+        final String addressResponseErrorField2 = "addressLine2";
+
+        final String addressResponseErrorMessage3 = "You must enter a response";
+        final String addressResponseErrorField3 = "city";
+
+        final String addressResponseErrorMessage4 = "response must be less than one bajillion characters";
+        final String addressResponseErrorField4 = "county";
+
+        final String addressResponseErrorMessage5 = "You must enter a response";
+        final String addressResponseErrorField5 = "postcode";
+
+        // set up validation failure
+        final ObjectError fieldError1 = new FieldError("question", addressResponseErrorField1, addressResponseErrorMessage1);
+        final ObjectError fieldError2 = new FieldError("question", addressResponseErrorField2, addressResponseErrorMessage2);
+        final ObjectError fieldError3 = new FieldError("question", addressResponseErrorField3, addressResponseErrorMessage3);
+        final ObjectError fieldError4 = new FieldError("question", addressResponseErrorField4, addressResponseErrorMessage4);
+        final ObjectError fieldError5 = new FieldError("question", addressResponseErrorField5, addressResponseErrorMessage5);
+
+        final BindingResult result = mock(BindingResult.class);
+        when(result.getAllErrors())
+                .thenReturn(
+                        List.of(fieldError5, fieldError2, fieldError1, fieldError3, fieldError4) // The rndom order ensures the sort definitely runs
+                );
+
+        // exception thrown by Spring when validation failure occurs
+        final MethodParameter parameter = mock(MethodParameter.class);
+        final MethodArgumentNotValidException ex = new MethodArgumentNotValidException(parameter, result);
+
+        // make the web request
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/some-uri");
+        request.setRemoteAddr("https://some-domain.com");
+
+        // Build the expected error message
+        final Error expectedFieldError1 = Error.builder()
+                .fieldName(addressResponseErrorField1)
+                .errorMessage(addressResponseErrorMessage1)
+                .build();
+        final Error expectedFieldError2 = Error.builder()
+                .fieldName(addressResponseErrorField2)
+                .errorMessage(addressResponseErrorMessage2)
+                .build();
+        final Error expectedFieldError3 = Error.builder()
+                .fieldName(addressResponseErrorField3)
+                .errorMessage(addressResponseErrorMessage3)
+                .build();
+        final Error expectedFieldError4 = Error.builder()
+                .fieldName(addressResponseErrorField4)
+                .errorMessage(addressResponseErrorMessage4)
+                .build();
+        final Error expectedFieldError5 = Error.builder()
+                .fieldName(addressResponseErrorField5)
+                .errorMessage(addressResponseErrorMessage5)
+                .build();
+        final ErrorResponseBody body = ErrorResponseBody.builder()
+                .responseAccepted(Boolean.FALSE)
+                .message("Validation failure")
+                .errors(List.of(
+                        expectedFieldError1,
+                        expectedFieldError2,
+                        expectedFieldError3,
+                        expectedFieldError4,
+                        expectedFieldError5
+                ))
+                .build();
+
+        ErrorResponseBody response = exceptionHandlerUnderTest.handleValidationExceptions(ex);
+
+        assertThat(response).isEqualTo(body);
+    }
+
     private static Stream<Arguments> provideBadRequests() {
         return Stream.of(
                 Arguments.of(new SubmissionNotReadyException("Submission is not ready")),


### PR DESCRIPTION
## Description
Fixing the sort order on question responses where multiple errors may appear on the screen at once. Previously these were just displayed in whatever order the code encountered the validation error but now they appear in the same order as the form. 

Ticket # and link
[GAP-1596](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-1596)

Summary of the changes and the related issue. List any dependencies that are required for this change:
Added a couple of methods to the controller exception handler to sort messages before they are returned back through the API

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.


[GAP-1596]: https://technologyprogramme.atlassian.net/browse/GAP-1596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ