### PR TITLE
Adding handling for grant beneficiary locations "outside uk" and "london"

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/dto/api/CreateGrantBeneficiaryDto.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/dto/api/CreateGrantBeneficiaryDto.java
@@ -21,6 +21,8 @@ public class CreateGrantBeneficiaryDto {
     private Boolean locationSco;
     private Boolean locationWal;
     private Boolean locationNir;
+    private Boolean locationLon;
+    private Boolean locationOutUk;
 
     @NotNull(message = "Select 'Yes, answer the equality questions' or 'No, skip the equality questions'")
     private Boolean hasProvidedAdditionalAnswers;

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/dto/api/GetGrantBeneficiaryDto.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/dto/api/GetGrantBeneficiaryDto.java
@@ -22,6 +22,8 @@ public class GetGrantBeneficiaryDto {
     private Boolean locationSco;
     private Boolean locationWal;
     private Boolean locationNir;
+    private Boolean locationLon;
+    private Boolean locationOutUk;
     private Boolean hasProvidedAdditionalAnswers;
     private Boolean ageGroup1;
     private Boolean ageGroup2;

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/model/GrantBeneficiary.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/model/GrantBeneficiary.java
@@ -84,6 +84,12 @@ public class GrantBeneficiary {
     private Boolean locationNir;
 
     @Column
+    private Boolean locationLon;
+
+    @Column
+    private Boolean locationOutUk;
+
+    @Column
     private Boolean hasProvidedAdditionalAnswers;
 
     @Column

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
@@ -367,6 +367,8 @@ public class SubmissionService {
                 .locationSco(containsLocation(locations, "Scotland"))
                 .locationWal(containsLocation(locations, "Wales"))
                 .locationNir(containsLocation(locations, "Northern Ireland"))
+                .locationLon(containsLocation(locations, "London"))
+                .locationOutUk(containsLocation(locations, "Outside of the UK"))
                 .gapId(submission.getGapId())
                 .build());
     }

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
@@ -53,7 +53,7 @@ class SubmissionServiceTest {
     final String amount = "1000";
     final String companiesHouseNo = "1234";
     final String charityNo = "1234";
-    final String[] beneficiaryLocation = new String[]{"South West England", "Midlands", "Scotland"};
+    final String[] beneficiaryLocation = new String[]{"South West England", "Midlands", "Scotland", "London"};
     final String userId = "75ab5fbd-0682-4d3d-a467-01c7a447f07c";
     private final String CHRISTMAS_2022_MIDDAY = "2022-12-25T12:00:00.00z";
     private final Clock clock = Clock.fixed(Instant.parse(CHRISTMAS_2022_MIDDAY), ZoneId.of("UTC"));
@@ -1350,6 +1350,8 @@ class SubmissionServiceTest {
             assertThat(capturedBeneficiary.getLocationMidEng()).isTrue();
             assertThat(capturedBeneficiary.getLocationSeEng()).isFalse();
             assertThat(capturedBeneficiary.getLocationNwEng()).isFalse();
+            assertThat(capturedBeneficiary.getLocationLon()).isTrue();
+            assertThat(capturedBeneficiary.getLocationOutUk()).isFalse();
             assertThat(capturedBeneficiary.getGapId()).isEqualTo(submission.getGapId());
         }
 


### PR DESCRIPTION

## Description

[Ticket # and link](https://technologyprogramme.atlassian.net/browse/TMI2-740)

Fixing issue where locations "outside of Uk" and "London" were not saving to the grant_beneficiary table on application submission.

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
