### PR TITLE
TMI2-732: Single and double quotation marks fix

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/validation/validators/QuestionResponseValidator.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/validation/validators/QuestionResponseValidator.java
@@ -215,7 +215,7 @@ public class QuestionResponseValidator implements ConstraintValidator<ValidQuest
     }
 
     private boolean containsSpecialCharacters(String response) {
-        return !response.matches("^(?![\\s\\S])|^[a-zA-Z0-9à-üÀ-Ü\\s',!@£$%^&*()_+=\\[\\];./?><:\"{}|`~ß€•–¥¢…µèéêëěẽýŷÿùúûüǔũūűìíîïǐĩiòóôöǒàáâäśğźžżćçčċñńņň-]+$");
+        return !response.matches("^(?![\\s\\S])|^[a-zA-Z0-9à-üÀ-Ü\\s',!@£$%^&*()_+=\\[\\];./?><:\"{}|`~ß€•–¥¢…µèéêëěẽýŷÿùúûüǔũūűìíîïǐĩiòóôöǒàáâäśğźžżćçčċñńņň-“”‘’]+$");
     }
 
     private ValidationResult validateDate(final String[] dateComponents, final boolean isMandatory) {


### PR DESCRIPTION
## Description

[TMI2-732](https://technologyprogramme.atlassian.net/browse/TMI2-732?atlOrigin=eyJpIjoiZTQzZGZmNDRkNTY5NGRjMjlhNGY2ZDM1MTU2MmU1Y2MiLCJwIjoiaiJ9)

As per the ticket, this PR involves adding a fix allowing for use of formatted single and double quotation marks that are often used when copying text from word documents.

![image](https://github.com/cabinetoffice/gap-find-applicant-backend/assets/127317407/32eaeee3-4279-488e-9d61-a035c70579a1)

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI chPlease attach screenshots of the change if it is a UI change:ange:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.


[TMI2-732]: https://technologyprogramme.atlassian.net/browse/TMI2-732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ