### PR TITLE
GAP-2795 Funding Amount Issue For Multi Applications

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/exception/SectionNotReadyException.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/exception/SectionNotReadyException.java
@@ -1,0 +1,7 @@
+package gov.cabinetoffice.gap.applybackend.exception;
+
+public class SectionNotReadyException extends RuntimeException {
+    public SectionNotReadyException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/model/GrantMandatoryQuestions.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/model/GrantMandatoryQuestions.java
@@ -88,7 +88,7 @@ public class GrantMandatoryQuestions extends BaseEntity {
 
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
-    @ColumnTransformer(write = "?::grant_mandatory_question_status")
+    @ColumnTransformer(read = "status::text", write = "?::grant_mandatory_question_status")
     @Builder.Default
     private GrantMandatoryQuestionStatus status = GrantMandatoryQuestionStatus.NOT_STARTED;
 

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/repository/GrantMandatoryQuestionRepository.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/repository/GrantMandatoryQuestionRepository.java
@@ -14,7 +14,9 @@ public interface GrantMandatoryQuestionRepository extends JpaRepository<GrantMan
 
     Optional<GrantMandatoryQuestions> findBySubmissionId(UUID submissionId);
 
-    Optional<GrantMandatoryQuestions> findByGrantScheme_IdAndCreatedBy_UserId(Integer schemeId, String sub);
+    // Multi-app schemes can have several MQ records per scheme+applicant (one per submission),
+    // so always resolve to the applicant's most recent MQ for the scheme.
+    Optional<GrantMandatoryQuestions> findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(Integer schemeId, String sub);
 
     boolean existsByGrantScheme_IdAndCreatedBy_Id(Integer schemeId, long applicantId);
 }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/repository/GrantMandatoryQuestionRepository.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/repository/GrantMandatoryQuestionRepository.java
@@ -1,5 +1,6 @@
 package gov.cabinetoffice.gap.applybackend.repository;
 
+import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionStatus;
 import gov.cabinetoffice.gap.applybackend.model.GrantApplicant;
 import gov.cabinetoffice.gap.applybackend.model.GrantMandatoryQuestions;
 import gov.cabinetoffice.gap.applybackend.model.GrantScheme;
@@ -17,6 +18,14 @@ public interface GrantMandatoryQuestionRepository extends JpaRepository<GrantMan
     // Multi-app schemes can have several MQ records per scheme+applicant (one per submission),
     // so always resolve to the applicant's most recent MQ for the scheme.
     Optional<GrantMandatoryQuestions> findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(Integer schemeId, String sub);
+
+    // Most recent MQ of a given status (e.g. COMPLETED) for the scheme+applicant. Used so routing can prefer a
+    // fully-entered previous MQ over a newer in-progress per-submission draft.
+    Optional<GrantMandatoryQuestions> findFirstByGrantScheme_IdAndCreatedBy_UserIdAndStatusOrderByCreatedDesc(Integer schemeId, String sub, GrantMandatoryQuestionStatus status);
+
+    // Most recent MQ that already belongs to a submission for the scheme+applicant. Used as a fallback when no MQ has
+    // reached COMPLETED but the applicant has nonetheless established their organisation details via a submission.
+    Optional<GrantMandatoryQuestions> findFirstByGrantScheme_IdAndCreatedBy_UserIdAndSubmissionIsNotNullOrderByCreatedDesc(Integer schemeId, String sub);
 
     boolean existsByGrantScheme_IdAndCreatedBy_Id(Integer schemeId, long applicantId);
 }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/repository/SubmissionRepository.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/repository/SubmissionRepository.java
@@ -11,6 +11,4 @@ public interface SubmissionRepository extends JpaRepository<Submission, UUID> {
     List<Submission> findByApplicantId(long applicantId);
     Optional<Submission> findByApplicantIdAndApplicationId(long applicantId, Integer applicationId);
     Optional<Submission> findByIdAndApplicantUserId(UUID id, String userId);
-
-    List<Submission> findByApplicant_IdAndScheme_Id(long applicantId, Integer schemeId);
 }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
@@ -167,6 +167,9 @@ public class GrantMandatoryQuestionService {
         if (SubmissionSectionStatus.COMPLETED.equals(fundingSection.getSectionStatus())) {
             fundingSection.setSectionStatus(SubmissionSectionStatus.IN_PROGRESS);
         }
+        // Blanking funding means the mandatory sections are no longer all complete. This cached flag is only otherwise
+        // recomputed during section review, so clear it here to keep it consistent with the now-incomplete funding.
+        submission.setMandatorySectionsCompleted(false);
         submissionRepository.save(submission);
 
         return savedMandatoryQuestion;

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
@@ -71,16 +71,23 @@ public class GrantMandatoryQuestionService {
     }
 
     public GrantMandatoryQuestions getMandatoryQuestionBySchemeId(Integer schemeId, String applicantSub) {
-        final Optional<GrantMandatoryQuestions> grantMandatoryQuestion = ofNullable(grantMandatoryQuestionRepository
-                .findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(schemeId, applicantSub)
-                .orElseThrow(() -> new NotFoundException(String.format("No Mandatory Question with scheme id  %s was found", schemeId))));
+        // Resolve the MQ that best represents the applicant's established organisation details for this scheme.
+        // Prefer the most recent COMPLETED record (their details are fully entered), then the most recent record that
+        // already belongs to a submission (organisation details established via a submission), and finally the most
+        // recent record of any kind. With the per-submission model the newest record is often an in-progress draft, so
+        // picking the newest overall would wrongly send applicants back through the full mandatory questions journey.
+        final GrantMandatoryQuestions grantMandatoryQuestion = grantMandatoryQuestionRepository
+                .findFirstByGrantScheme_IdAndCreatedBy_UserIdAndStatusOrderByCreatedDesc(schemeId, applicantSub, GrantMandatoryQuestionStatus.COMPLETED)
+                .or(() -> grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdAndSubmissionIsNotNullOrderByCreatedDesc(schemeId, applicantSub))
+                .or(() -> grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(schemeId, applicantSub))
+                .orElseThrow(() -> new NotFoundException(String.format("No Mandatory Question with scheme id  %s was found", schemeId)));
 
-        if (!grantMandatoryQuestion.get().getCreatedBy().getUserId().equals(applicantSub)) {
+        if (!grantMandatoryQuestion.getCreatedBy().getUserId().equals(applicantSub)) {
             throw new ForbiddenException(String.format("Mandatory Question with id %s and scheme ID %s was not created by %s",
-                    grantMandatoryQuestion.get().getId(), schemeId, applicantSub));
+                    grantMandatoryQuestion.getId(), schemeId, applicantSub));
         }
 
-        return grantMandatoryQuestion.get();
+        return grantMandatoryQuestion;
     }
 
     public GrantMandatoryQuestions createMandatoryQuestion(GrantScheme scheme, GrantApplicant applicant, boolean isForInternalApplication) {

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
@@ -173,10 +173,13 @@ public class GrantMandatoryQuestionService {
      * Legacy multi-application submissions could share a single MQ record. Editing such a submission's
      * organisation or funding details would otherwise land on whichever submission the shared record happened
      * to point at, silently altering a sibling. This guarantees the submission being edited owns its MQ: if one
-     * is already linked it is returned unchanged; otherwise a new record is created, seeded from the submission's
-     * own definition (its source of truth, so the figures stay isolated), and linked to it. The shared record is
-     * never re-pointed. Submitted submissions are immutable and left untouched - those are handled by the
-     * separate remediation job - as are version 1 schemes, which do not use MQ-backed sections.
+     * is already linked it is returned unchanged; otherwise a new record is created, with organisation details
+     * seeded from the submission's own definition but funding deliberately blanked - because the funding figures
+     * may have been corrupted by a shared record, the applicant must re-confirm them. The blanked funding is
+     * projected back into the submission and its funding section reopened so it cannot be completed or submitted
+     * until re-entered. The shared record is never re-pointed. Submitted submissions are immutable and left
+     * untouched - those are handled by the separate remediation job - as are version 1 schemes, which do not use
+     * MQ-backed sections.
      */
     public GrantMandatoryQuestions ensureMandatoryQuestionForSubmission(final UUID submissionId, final String applicantSub) {
         final Submission submission = submissionRepository.findByIdAndApplicantUserId(submissionId, applicantSub)
@@ -191,16 +194,30 @@ public class GrantMandatoryQuestionService {
             return getGrantMandatoryQuestionBySubmissionIdAndApplicantSub(submissionId, applicantSub);
         }
 
-        log.info("Submission {} has no mandatory question of its own; creating one seeded from its definition", submissionId);
+        log.info("Submission {} has no mandatory question of its own; creating one and reopening its funding", submissionId);
 
         final GrantMandatoryQuestions perSubmissionMandatoryQuestion = buildMandatoryQuestionFromSubmissionDefinition(submission);
         perSubmissionMandatoryQuestion.setStatus(GrantMandatoryQuestionStatus.IN_PROGRESS);
         perSubmissionMandatoryQuestion.setGapId(null);
+        // This submission was relying on a sibling's mandatory question, so the funding figures in its definition may
+        // have been overwritten by that sibling and cannot be trusted. Blank them (mirroring a brand-new submission) so
+        // the applicant must re-confirm funding for this submission before its funding section can be completed or submitted.
+        perSubmissionMandatoryQuestion.setFundingAmount(null);
+        perSubmissionMandatoryQuestion.setFundingLocation(null);
         perSubmissionMandatoryQuestion.setGrantScheme(submission.getScheme());
         perSubmissionMandatoryQuestion.setCreatedBy(submission.getApplicant());
         perSubmissionMandatoryQuestion.setSubmission(submission);
 
-        return grantMandatoryQuestionRepository.save(perSubmissionMandatoryQuestion);
+        final GrantMandatoryQuestions savedMandatoryQuestion = grantMandatoryQuestionRepository.save(perSubmissionMandatoryQuestion);
+
+        // Project the blanked funding into this submission's definition and reopen its funding section so the existing
+        // section-completion and submit-readiness checks force the applicant to re-enter funding for this submission.
+        addMandatoryQuestionsToSubmissionObject(savedMandatoryQuestion);
+        submission.getSection(MandatoryQuestionConstants.FUNDING_DETAILS_SECTION_ID)
+                .setSectionStatus(SubmissionSectionStatus.IN_PROGRESS);
+        submissionRepository.save(submission);
+
+        return savedMandatoryQuestion;
     }
 
     private GrantMandatoryQuestions buildMandatoryQuestionFromSubmissionDefinition(final Submission submission) {

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
@@ -114,72 +114,21 @@ public class GrantMandatoryQuestionService {
     }
 
     /**
-     * Creates a dedicated mandatory-questions record for a newly created submission.
+     * Guarantees the given submission owns its own mandatory-questions record (copy-on-write), creating one if needed.
      * <p>
-     * Multi-application schemes must not share a single MQ record across submissions (doing so caused
-     * one submission's funding figures to overwrite another's). This copies the organisation and address
-     * details from the applicant's most recent MQ for the scheme (their immediately previous submission),
-     * but deliberately leaves the funding amount, funding location and gapId blank so they are entered
-     * fresh for this submission. The copied details are then projected into this submission only.
-     */
-    public GrantMandatoryQuestions createMandatoryQuestionForNewSubmission(final UUID submissionId, final String applicantSub) {
-        final Submission submission = submissionRepository.findByIdAndApplicantUserId(submissionId, applicantSub)
-                .orElseThrow(() -> new NotFoundException(String.format("No submission with id %s was found for the current applicant", submissionId)));
-
-        final Optional<GrantMandatoryQuestions> existing = grantMandatoryQuestionRepository.findBySubmissionId(submissionId);
-        if (existing.isPresent()) {
-            return existing.get();
-        }
-
-        final GrantApplicant applicant = submission.getApplicant();
-        final Integer schemeId = submission.getScheme().getId();
-
-        final GrantMandatoryQuestions newMandatoryQuestion = grantMandatoryQuestionRepository
-                .findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(schemeId, applicantSub)
-                .map(source -> GrantMandatoryQuestions.builder()
-                        .orgType(source.getOrgType())
-                        .name(source.getName())
-                        .addressLine1(source.getAddressLine1())
-                        .addressLine2(source.getAddressLine2())
-                        .city(source.getCity())
-                        .county(source.getCounty())
-                        .postcode(source.getPostcode())
-                        .companiesHouseNumber(source.getCompaniesHouseNumber())
-                        .charityCommissionNumber(source.getCharityCommissionNumber())
-                        .build())
-                .orElseGet(() -> organisationProfileMapper
-                        .mapOrgProfileToGrantMandatoryQuestion(applicant.getOrganisationProfile()));
-
-        // Funding details are intentionally blanked so each submission captures its own values.
-        newMandatoryQuestion.setFundingAmount(null);
-        newMandatoryQuestion.setFundingLocation(null);
-        newMandatoryQuestion.setGapId(null);
-        newMandatoryQuestion.setStatus(GrantMandatoryQuestionStatus.IN_PROGRESS);
-        newMandatoryQuestion.setGrantScheme(submission.getScheme());
-        newMandatoryQuestion.setCreatedBy(applicant);
-        newMandatoryQuestion.setSubmission(submission);
-
-        final GrantMandatoryQuestions saved = grantMandatoryQuestionRepository.save(newMandatoryQuestion);
-
-        addMandatoryQuestionsToSubmissionObject(saved);
-        submissionRepository.save(submission);
-
-        return saved;
-    }
-
-    /**
-     * Ensures the given submission owns its own mandatory-questions record before it is edited (copy-on-write).
+     * This is the single entry point for giving a submission its own MQ, covering both a brand-new multi-application
+     * submission and a legacy submission that was sharing a sibling's record. Multi-application schemes must not share
+     * a single MQ across submissions (doing so caused one submission's funding figures to overwrite another's).
      * <p>
-     * Legacy multi-application submissions could share a single MQ record. Editing such a submission's
-     * organisation or funding details would otherwise land on whichever submission the shared record happened
-     * to point at, silently altering a sibling. This guarantees the submission being edited owns its MQ: if one
-     * is already linked it is returned unchanged; otherwise a new record is created, with organisation details
-     * seeded from the submission's own definition but funding deliberately blanked - because the funding figures
-     * may have been corrupted by a shared record, the applicant must re-confirm them. The blanked funding is
-     * projected back into the submission and its funding section reopened so it cannot be completed or submitted
-     * until re-entered. The shared record is never re-pointed. Submitted submissions are immutable and left
-     * untouched - those are handled by the separate remediation job - as are version 1 schemes, which do not use
-     * MQ-backed sections.
+     * If the submission already owns an MQ it is returned unchanged. Otherwise a new record is created: organisation
+     * details are seeded from the submission's own definition when present (a legacy draft), falling back to the
+     * applicant's most recent MQ for the scheme and then their organisation profile (a brand-new submission whose
+     * definition has no organisation responses yet). Funding amount, funding location and gapId are always blanked so
+     * each submission captures its own funding, and the blanked funding is projected back into the submission. A
+     * funding section that was already COMPLETED (a healed draft) is reopened so it cannot be completed or submitted
+     * until re-entered; a brand-new submission keeps its default funding-section status. The shared record is never
+     * re-pointed. Submitted submissions are immutable and left untouched - those are handled by the separate
+     * remediation job - as are version 1 schemes, which do not use MQ-backed sections.
      */
     public GrantMandatoryQuestions ensureMandatoryQuestionForSubmission(final UUID submissionId, final String applicantSub) {
         final Submission submission = submissionRepository.findByIdAndApplicantUserId(submissionId, applicantSub)
@@ -194,14 +143,14 @@ public class GrantMandatoryQuestionService {
             return getGrantMandatoryQuestionBySubmissionIdAndApplicantSub(submissionId, applicantSub);
         }
 
-        log.info("Submission {} has no mandatory question of its own; creating one and reopening its funding", submissionId);
+        log.info("Submission {} has no mandatory question of its own; creating one and blanking its funding", submissionId);
 
-        final GrantMandatoryQuestions perSubmissionMandatoryQuestion = buildMandatoryQuestionFromSubmissionDefinition(submission);
+        final GrantMandatoryQuestions perSubmissionMandatoryQuestion = buildPerSubmissionOrganisationDetails(submission, applicantSub);
         perSubmissionMandatoryQuestion.setStatus(GrantMandatoryQuestionStatus.IN_PROGRESS);
         perSubmissionMandatoryQuestion.setGapId(null);
-        // This submission was relying on a sibling's mandatory question, so the funding figures in its definition may
-        // have been overwritten by that sibling and cannot be trusted. Blank them (mirroring a brand-new submission) so
-        // the applicant must re-confirm funding for this submission before its funding section can be completed or submitted.
+        // Funding is never inherited: a borrowed sibling record may have overwritten this submission's funding, and a
+        // brand-new submission must capture its own. Blank it so the applicant must (re)confirm funding for this
+        // submission before its funding section can be completed or submitted.
         perSubmissionMandatoryQuestion.setFundingAmount(null);
         perSubmissionMandatoryQuestion.setFundingLocation(null);
         perSubmissionMandatoryQuestion.setGrantScheme(submission.getScheme());
@@ -210,14 +159,48 @@ public class GrantMandatoryQuestionService {
 
         final GrantMandatoryQuestions savedMandatoryQuestion = grantMandatoryQuestionRepository.save(perSubmissionMandatoryQuestion);
 
-        // Project the blanked funding into this submission's definition and reopen its funding section so the existing
-        // section-completion and submit-readiness checks force the applicant to re-enter funding for this submission.
+        // Project the blanked funding into this submission's definition. Only reopen a funding section that was already
+        // COMPLETED (a healed draft) so the section-completion / submit-readiness checks force re-entry; a brand-new
+        // submission keeps its default funding-section status.
         addMandatoryQuestionsToSubmissionObject(savedMandatoryQuestion);
-        submission.getSection(MandatoryQuestionConstants.FUNDING_DETAILS_SECTION_ID)
-                .setSectionStatus(SubmissionSectionStatus.IN_PROGRESS);
+        final SubmissionSection fundingSection = submission.getSection(MandatoryQuestionConstants.FUNDING_DETAILS_SECTION_ID);
+        if (SubmissionSectionStatus.COMPLETED.equals(fundingSection.getSectionStatus())) {
+            fundingSection.setSectionStatus(SubmissionSectionStatus.IN_PROGRESS);
+        }
         submissionRepository.save(submission);
 
         return savedMandatoryQuestion;
+    }
+
+    /**
+     * Builds the organisation details for a new per-submission mandatory question. An existing draft carries its
+     * organisation details in its own definition, so they are seeded from there. A brand-new submission has no
+     * organisation responses in its definition yet, so they are seeded from the applicant's most recent mandatory
+     * question for the scheme (their previous submission), falling back to their organisation profile. Funding is
+     * blanked by the caller in every case.
+     */
+    private GrantMandatoryQuestions buildPerSubmissionOrganisationDetails(final Submission submission, final String applicantSub) {
+        final GrantMandatoryQuestions fromDefinition = buildMandatoryQuestionFromSubmissionDefinition(submission);
+        if (fromDefinition.getOrgType() != null) {
+            return fromDefinition;
+        }
+
+        final Integer schemeId = submission.getScheme().getId();
+        return grantMandatoryQuestionRepository
+                .findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(schemeId, applicantSub)
+                .map(source -> GrantMandatoryQuestions.builder()
+                        .orgType(source.getOrgType())
+                        .name(source.getName())
+                        .addressLine1(source.getAddressLine1())
+                        .addressLine2(source.getAddressLine2())
+                        .city(source.getCity())
+                        .county(source.getCounty())
+                        .postcode(source.getPostcode())
+                        .companiesHouseNumber(source.getCompaniesHouseNumber())
+                        .charityCommissionNumber(source.getCharityCommissionNumber())
+                        .build())
+                .orElseGet(() -> organisationProfileMapper
+                        .mapOrgProfileToGrantMandatoryQuestion(submission.getApplicant().getOrganisationProfile()));
     }
 
     private GrantMandatoryQuestions buildMandatoryQuestionFromSubmissionDefinition(final Submission submission) {

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.*;
 
 import static java.util.Optional.ofNullable;
@@ -164,6 +165,109 @@ public class GrantMandatoryQuestionService {
         submissionRepository.save(submission);
 
         return saved;
+    }
+
+    /**
+     * Ensures the given submission owns its own mandatory-questions record before it is edited (copy-on-write).
+     * <p>
+     * Legacy multi-application submissions could share a single MQ record. Editing such a submission's
+     * organisation or funding details would otherwise land on whichever submission the shared record happened
+     * to point at, silently altering a sibling. This guarantees the submission being edited owns its MQ: if one
+     * is already linked it is returned unchanged; otherwise a new record is created, seeded from the submission's
+     * own definition (its source of truth, so the figures stay isolated), and linked to it. The shared record is
+     * never re-pointed. Submitted submissions are immutable and left untouched - those are handled by the
+     * separate remediation job - as are version 1 schemes, which do not use MQ-backed sections.
+     */
+    public GrantMandatoryQuestions ensureMandatoryQuestionForSubmission(final UUID submissionId, final String applicantSub) {
+        final Submission submission = submissionRepository.findByIdAndApplicantUserId(submissionId, applicantSub)
+                .orElseThrow(() -> new NotFoundException(String.format("No submission with id %s was found for the current applicant", submissionId)));
+
+        final Optional<GrantMandatoryQuestions> ownMandatoryQuestion = grantMandatoryQuestionRepository.findBySubmissionId(submissionId);
+        if (ownMandatoryQuestion.isPresent()) {
+            return ownMandatoryQuestion.get();
+        }
+
+        if (SubmissionStatus.SUBMITTED.equals(submission.getStatus()) || submission.getScheme().getVersion() <= 1) {
+            return getGrantMandatoryQuestionBySubmissionIdAndApplicantSub(submissionId, applicantSub);
+        }
+
+        log.info("Submission {} has no mandatory question of its own; creating one seeded from its definition", submissionId);
+
+        final GrantMandatoryQuestions perSubmissionMandatoryQuestion = buildMandatoryQuestionFromSubmissionDefinition(submission);
+        perSubmissionMandatoryQuestion.setStatus(GrantMandatoryQuestionStatus.IN_PROGRESS);
+        perSubmissionMandatoryQuestion.setGapId(null);
+        perSubmissionMandatoryQuestion.setGrantScheme(submission.getScheme());
+        perSubmissionMandatoryQuestion.setCreatedBy(submission.getApplicant());
+        perSubmissionMandatoryQuestion.setSubmission(submission);
+
+        return grantMandatoryQuestionRepository.save(perSubmissionMandatoryQuestion);
+    }
+
+    private GrantMandatoryQuestions buildMandatoryQuestionFromSubmissionDefinition(final Submission submission) {
+        final GrantMandatoryQuestions mandatoryQuestions = GrantMandatoryQuestions.builder().build();
+
+        findSubmissionQuestion(submission, MandatoryQuestionConstants.ORGANISATION_DETAILS_SECTION_ID,
+                MandatoryQuestionConstants.SUBMISSION_QUESTION_IDS.APPLICANT_TYPE.toString())
+                .map(SubmissionQuestion::getResponse)
+                .map(GrantMandatoryQuestionOrgType::valueOfName)
+                .ifPresent(mandatoryQuestions::setOrgType);
+
+        findSubmissionQuestion(submission, MandatoryQuestionConstants.ORGANISATION_DETAILS_SECTION_ID,
+                MandatoryQuestionConstants.SUBMISSION_QUESTION_IDS.APPLICANT_ORG_NAME.toString())
+                .map(SubmissionQuestion::getResponse)
+                .ifPresent(mandatoryQuestions::setName);
+
+        findSubmissionQuestion(submission, MandatoryQuestionConstants.ORGANISATION_DETAILS_SECTION_ID,
+                MandatoryQuestionConstants.SUBMISSION_QUESTION_IDS.APPLICANT_ORG_ADDRESS.toString())
+                .map(SubmissionQuestion::getMultiResponse)
+                .ifPresent(address -> {
+                    mandatoryQuestions.setAddressLine1(elementOrNull(address, 0));
+                    mandatoryQuestions.setAddressLine2(elementOrNull(address, 1));
+                    mandatoryQuestions.setCity(elementOrNull(address, 2));
+                    mandatoryQuestions.setCounty(elementOrNull(address, 3));
+                    mandatoryQuestions.setPostcode(elementOrNull(address, 4));
+                });
+
+        findSubmissionQuestion(submission, MandatoryQuestionConstants.ORGANISATION_DETAILS_SECTION_ID,
+                MandatoryQuestionConstants.SUBMISSION_QUESTION_IDS.APPLICANT_ORG_CHARITY_NUMBER.toString())
+                .map(SubmissionQuestion::getResponse)
+                .ifPresent(mandatoryQuestions::setCharityCommissionNumber);
+
+        findSubmissionQuestion(submission, MandatoryQuestionConstants.ORGANISATION_DETAILS_SECTION_ID,
+                MandatoryQuestionConstants.SUBMISSION_QUESTION_IDS.APPLICANT_ORG_COMPANIES_HOUSE.toString())
+                .map(SubmissionQuestion::getResponse)
+                .ifPresent(mandatoryQuestions::setCompaniesHouseNumber);
+
+        findSubmissionQuestion(submission, MandatoryQuestionConstants.FUNDING_DETAILS_SECTION_ID,
+                MandatoryQuestionConstants.SUBMISSION_QUESTION_IDS.APPLICANT_AMOUNT.toString())
+                .map(SubmissionQuestion::getResponse)
+                .filter(response -> !response.isBlank())
+                .map(BigDecimal::new)
+                .ifPresent(mandatoryQuestions::setFundingAmount);
+
+        findSubmissionQuestion(submission, MandatoryQuestionConstants.FUNDING_DETAILS_SECTION_ID,
+                MandatoryQuestionConstants.SUBMISSION_QUESTION_IDS.BENEFITIARY_LOCATION.toString())
+                .map(SubmissionQuestion::getMultiResponse)
+                .ifPresent(locations -> mandatoryQuestions.setFundingLocation(
+                        Arrays.stream(locations)
+                                .map(GrantMandatoryQuestionFundingLocation::valueOfName)
+                                .filter(Objects::nonNull)
+                                .toArray(GrantMandatoryQuestionFundingLocation[]::new)));
+
+        return mandatoryQuestions;
+    }
+
+    private Optional<SubmissionQuestion> findSubmissionQuestion(final Submission submission, final String sectionId, final String questionId) {
+        return submission.getDefinition().getSections().stream()
+                .filter(section -> sectionId.equals(section.getSectionId()))
+                .filter(section -> section.getQuestions() != null)
+                .flatMap(section -> section.getQuestions().stream())
+                .filter(question -> questionId.equals(question.getQuestionId()))
+                .findFirst();
+    }
+
+    private static String elementOrNull(final String[] array, final int index) {
+        return array != null && array.length > index ? array[index] : null;
     }
 
 

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionService.java
@@ -55,7 +55,7 @@ public class GrantMandatoryQuestionService {
                     .getScheme()
                     .getId();
 
-            grantMandatoryQuestion = grantMandatoryQuestionRepository.findByGrantScheme_IdAndCreatedBy_UserId(schemeId, applicantSub);
+            grantMandatoryQuestion = grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(schemeId, applicantSub);
 
             if (grantMandatoryQuestion.isEmpty()) {
                 throw new NotFoundException(String.format("No Mandatory Question with submission id %s was found", submissionId));
@@ -71,7 +71,7 @@ public class GrantMandatoryQuestionService {
 
     public GrantMandatoryQuestions getMandatoryQuestionBySchemeId(Integer schemeId, String applicantSub) {
         final Optional<GrantMandatoryQuestions> grantMandatoryQuestion = ofNullable(grantMandatoryQuestionRepository
-                .findByGrantScheme_IdAndCreatedBy_UserId(schemeId, applicantSub)
+                .findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(schemeId, applicantSub)
                 .orElseThrow(() -> new NotFoundException(String.format("No Mandatory Question with scheme id  %s was found", schemeId))));
 
         if (!grantMandatoryQuestion.get().getCreatedBy().getUserId().equals(applicantSub)) {
@@ -110,6 +110,60 @@ public class GrantMandatoryQuestionService {
         grantMandatoryQuestions.setCreatedBy(applicant);
 
         return grantMandatoryQuestionRepository.save(grantMandatoryQuestions);
+    }
+
+    /**
+     * Creates a dedicated mandatory-questions record for a newly created submission.
+     * <p>
+     * Multi-application schemes must not share a single MQ record across submissions (doing so caused
+     * one submission's funding figures to overwrite another's). This copies the organisation and address
+     * details from the applicant's most recent MQ for the scheme (their immediately previous submission),
+     * but deliberately leaves the funding amount, funding location and gapId blank so they are entered
+     * fresh for this submission. The copied details are then projected into this submission only.
+     */
+    public GrantMandatoryQuestions createMandatoryQuestionForNewSubmission(final UUID submissionId, final String applicantSub) {
+        final Submission submission = submissionRepository.findByIdAndApplicantUserId(submissionId, applicantSub)
+                .orElseThrow(() -> new NotFoundException(String.format("No submission with id %s was found for the current applicant", submissionId)));
+
+        final Optional<GrantMandatoryQuestions> existing = grantMandatoryQuestionRepository.findBySubmissionId(submissionId);
+        if (existing.isPresent()) {
+            return existing.get();
+        }
+
+        final GrantApplicant applicant = submission.getApplicant();
+        final Integer schemeId = submission.getScheme().getId();
+
+        final GrantMandatoryQuestions newMandatoryQuestion = grantMandatoryQuestionRepository
+                .findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(schemeId, applicantSub)
+                .map(source -> GrantMandatoryQuestions.builder()
+                        .orgType(source.getOrgType())
+                        .name(source.getName())
+                        .addressLine1(source.getAddressLine1())
+                        .addressLine2(source.getAddressLine2())
+                        .city(source.getCity())
+                        .county(source.getCounty())
+                        .postcode(source.getPostcode())
+                        .companiesHouseNumber(source.getCompaniesHouseNumber())
+                        .charityCommissionNumber(source.getCharityCommissionNumber())
+                        .build())
+                .orElseGet(() -> organisationProfileMapper
+                        .mapOrgProfileToGrantMandatoryQuestion(applicant.getOrganisationProfile()));
+
+        // Funding details are intentionally blanked so each submission captures its own values.
+        newMandatoryQuestion.setFundingAmount(null);
+        newMandatoryQuestion.setFundingLocation(null);
+        newMandatoryQuestion.setGapId(null);
+        newMandatoryQuestion.setStatus(GrantMandatoryQuestionStatus.IN_PROGRESS);
+        newMandatoryQuestion.setGrantScheme(submission.getScheme());
+        newMandatoryQuestion.setCreatedBy(applicant);
+        newMandatoryQuestion.setSubmission(submission);
+
+        final GrantMandatoryQuestions saved = grantMandatoryQuestionRepository.save(newMandatoryQuestion);
+
+        addMandatoryQuestionsToSubmissionObject(saved);
+        submissionRepository.save(submission);
+
+        return saved;
     }
 
 
@@ -158,21 +212,10 @@ public class GrantMandatoryQuestionService {
             return;
         }
 
-        // Update the submission linked to the MQ (saved via cascade when the MQ is saved)
+        // Each submission has its own mandatory-questions record, so the responses are applied only to
+        // the submission linked to this MQ. There is deliberately NO cross-submission propagation:
+        // updating one submission's MQ must never alter another submission's funding details.
         applyMandatoryQuestionsToSubmission(submission, mandatoryQuestions);
-
-        // In multi-app schemes there may be other submissions for this applicant+scheme whose
-        // stored sections need to be kept in sync with the shared MQ record.
-        final GrantApplicant createdBy = mandatoryQuestions.getCreatedBy();
-        if (createdBy != null) {
-            submissionRepository.findByApplicant_IdAndScheme_Id(createdBy.getId(), submission.getScheme().getId())
-                    .stream()
-                    .filter(s -> !s.getId().equals(submission.getId()))
-                    .forEach(s -> {
-                        applyMandatoryQuestionsToSubmission(s, mandatoryQuestions);
-                        submissionRepository.save(s);
-                    });
-        }
     }
 
     private void applyMandatoryQuestionsToSubmission(final Submission submission,
@@ -373,15 +416,20 @@ public class GrantMandatoryQuestionService {
                 .adminSummary(MandatoryQuestionConstants.APPLICANT_AMOUNT_ADMIN_SUMMARY)
                 .fieldPrefix(MandatoryQuestionConstants.APPLICANT_AMOUNT_PREFIX)
                 .responseType(SubmissionQuestionResponseType.Numeric)
-                .response(mandatoryQuestions.getFundingAmount().toString())
+                .response(mandatoryQuestions.getFundingAmount() != null
+                        ? mandatoryQuestions.getFundingAmount().toString()
+                        : null)
                 .validation(validation)
                 .build();
     }
 
     private SubmissionQuestion buildFundingLocationQuestion(final GrantMandatoryQuestions mandatoryQuestions) {
-        final String[] locations = Arrays.stream(mandatoryQuestions.getFundingLocation())
-                .map(GrantMandatoryQuestionFundingLocation::getName)
-                .toArray(String[]::new);
+        final GrantMandatoryQuestionFundingLocation[] fundingLocations = mandatoryQuestions.getFundingLocation();
+        final String[] locations = fundingLocations == null
+                ? new String[0]
+                : Arrays.stream(fundingLocations)
+                        .map(GrantMandatoryQuestionFundingLocation::getName)
+                        .toArray(String[]::new);
 
         final SubmissionQuestionValidation validation = SubmissionQuestionValidation.builder()
                 .mandatory(true)

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
@@ -13,6 +13,7 @@ import gov.cabinetoffice.gap.applybackend.enums.SubmissionSectionStatus;
 import gov.cabinetoffice.gap.applybackend.enums.SubmissionStatus;
 import gov.cabinetoffice.gap.applybackend.exception.ForbiddenException;
 import gov.cabinetoffice.gap.applybackend.exception.NotFoundException;
+import gov.cabinetoffice.gap.applybackend.exception.SectionNotReadyException;
 import gov.cabinetoffice.gap.applybackend.exception.SubmissionAlreadySubmittedException;
 import gov.cabinetoffice.gap.applybackend.exception.SubmissionNotReadyException;
 import gov.cabinetoffice.gap.applybackend.model.*;
@@ -247,10 +248,14 @@ public class SubmissionService {
         final int version = submission.getScheme().getVersion();
 
         final Optional<GrantMandatoryQuestions> grantMandatoryQuestion = grantMandatoryQuestionRepository.findBySubmissionId(submission.getId());
+        final String existingGapId = grantMandatoryQuestion.map(GrantMandatoryQuestions::getGapId).orElse(null);
         final String gapId;
-        if (grantMandatoryQuestion.isPresent()) {
-            gapId = grantMandatoryQuestion.get().getGapId();
+        if (existingGapId != null && !existingGapId.isBlank()) {
+            gapId = existingGapId;
         } else {
+            // A per-submission mandatory question created by copy-on-write has no gapId of its own (it is only minted
+            // when the MQ journey is marked complete). Mint one at submit time so we never freeze a null reference onto
+            // the submission, its diligence check or its grant beneficiary record.
             gapId = GapIdGenerator.generateGapId(
                     grantApplicant.getId(),
                     envProperties.getEnvironmentName(),
@@ -261,6 +266,7 @@ public class SubmissionService {
         submission.setGapId(gapId);
 
         submitApplication(submission);
+        setMandatoryQuestionsGapId(submission);
         notifyClient.sendConfirmationEmail(emailAddress, submission);
         createDiligenceCheckFromSubmission(submission);
         createGrantBeneficiary(submission);
@@ -576,19 +582,43 @@ public class SubmissionService {
                                                        final String sectionId,
                                                        final boolean isComplete) {
         final Submission submission = getSubmissionFromDatabaseBySubmissionId(userId, submissionId);
-        final SubmissionSectionStatus sectionStatus = isComplete ? SubmissionSectionStatus.COMPLETED : SubmissionSectionStatus.IN_PROGRESS;
-        submission.getDefinition()
+        final SubmissionSection section = submission.getDefinition()
                 .getSections()
                 .stream()
                 .filter(submissionSection -> submissionSection.getSectionId().equals(sectionId))
                 .findFirst()
-                .orElseThrow(() -> new NotFoundException(String.format("No section with ID %s was found", sectionId)))
-                .setSectionStatus(sectionStatus);
+                .orElseThrow(() -> new NotFoundException(String.format("No section with ID %s was found", sectionId)));
+
+        // A section can only be marked complete once every mandatory question in it has an answer. Without this guard a
+        // section whose funding details were left blank (e.g. a freshly created per-submission mandatory question) could
+        // show as COMPLETED on the UI even though the submission can never actually be submitted, which confuses applicants.
+        if (isComplete && !areAllMandatoryQuestionsAnswered(section)) {
+            throw new SectionNotReadyException(
+                    "You must answer every question in this section before you can mark it as completed.");
+        }
+
+        final SubmissionSectionStatus sectionStatus = isComplete ? SubmissionSectionStatus.COMPLETED : SubmissionSectionStatus.IN_PROGRESS;
+        section.setSectionStatus(sectionStatus);
 
         updateMandatorySectionsCompletedFlag(submission);
 
         submissionRepository.save(submission);
         return sectionStatus;
+    }
+
+    private boolean areAllMandatoryQuestionsAnswered(final SubmissionSection section) {
+        if (section.getQuestions() == null) {
+            return true;
+        }
+        return section.getQuestions().stream()
+                .filter(question -> question.getValidation() != null && question.getValidation().isMandatory())
+                .allMatch(question -> {
+                    final boolean responseIsEmptyOrNull = question.getResponse() == null
+                            || question.getResponse().isBlank();
+                    final boolean multiResponseArrayIsEmptyOrNull = question.getMultiResponse() == null
+                            || question.getMultiResponse().length < 1;
+                    return !(responseIsEmptyOrNull && multiResponseArrayIsEmptyOrNull);
+                });
     }
 
     private void updateMandatorySectionsCompletedFlag(final Submission submission) {

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/SubmissionService.java
@@ -9,6 +9,7 @@ import gov.cabinetoffice.gap.applybackend.dto.api.CreateQuestionResponseDto;
 import gov.cabinetoffice.gap.applybackend.dto.api.CreateSubmissionResponseDto;
 import gov.cabinetoffice.gap.applybackend.dto.api.GetNavigationParamsDto;
 import gov.cabinetoffice.gap.applybackend.enums.GrantApplicationStatus;
+import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionStatus;
 import gov.cabinetoffice.gap.applybackend.enums.SubmissionSectionStatus;
 import gov.cabinetoffice.gap.applybackend.enums.SubmissionStatus;
 import gov.cabinetoffice.gap.applybackend.exception.ForbiddenException;
@@ -287,6 +288,11 @@ public class SubmissionService {
             final Optional<GrantMandatoryQuestions> grantMandatoryQuestion = ofNullable(grantMandatoryQuestionRepository.findBySubmissionId(submissionId)
                     .orElseThrow(() -> new NotFoundException(String.format("No mandatory questions with submission id %s was found", submissionId))));
             grantMandatoryQuestion.get().setGapId(submission.getGapId());
+            // Safety net for any per-submission mandatory question that never reached the section-review completion (e.g.
+            // a legacy draft whose sections were marked complete before that logic existed): it would otherwise stay
+            // IN_PROGRESS after submission and be excluded from the admin due-diligence / Spotlight exports. A
+            // single-application MQ is already COMPLETED by this point, so this is a no-op for it.
+            grantMandatoryQuestion.get().setStatus(GrantMandatoryQuestionStatus.COMPLETED);
             grantMandatoryQuestionRepository.save(grantMandatoryQuestion.get());
 
         } catch (NotFoundException e) {
@@ -600,10 +606,60 @@ public class SubmissionService {
         final SubmissionSectionStatus sectionStatus = isComplete ? SubmissionSectionStatus.COMPLETED : SubmissionSectionStatus.IN_PROGRESS;
         section.setSectionStatus(sectionStatus);
 
+        if (isComplete && isMandatoryQuestionSection(sectionId)) {
+            completeMandatoryQuestionForSubmissionIfSectionsFinished(submission);
+        }
+
         updateMandatorySectionsCompletedFlag(submission);
 
         submissionRepository.save(submission);
         return sectionStatus;
+    }
+
+    private boolean isMandatoryQuestionSection(final String sectionId) {
+        return ORGANISATION_DETAILS.equals(sectionId) || FUNDING_DETAILS.equals(sectionId);
+    }
+
+    /**
+     * Marks a submission's per-submission mandatory-questions record as completed once both of its backing sections
+     * (organisation and funding details) have been completed.
+     * <p>
+     * Multi-application / lazy-healed submissions own an MQ record that is created {@code IN_PROGRESS} and never passes
+     * through the mandatory-questions "check your answers" step (the step that completes a single-application MQ and
+     * mints its gapId). Left alone it stays {@code IN_PROGRESS} forever, which hides it from the admin due-diligence /
+     * Spotlight exports (they only include {@code COMPLETED} records).
+     * <p>
+     * This is a deliberately one-way transition guarded on the MQ not already being {@code COMPLETED}: a
+     * single-application MQ is already completed (with a gapId) before its sections are reviewed, so it is left entirely
+     * untouched here - no re-completion, no gapId churn and, crucially, no flip back to {@code IN_PROGRESS} if a section
+     * is later re-opened. The gapId is only minted when absent, so an existing single-application gapId is never replaced.
+     */
+    private void completeMandatoryQuestionForSubmissionIfSectionsFinished(final Submission submission) {
+        if (!isSectionComplete(submission, ORGANISATION_DETAILS) || !isSectionComplete(submission, FUNDING_DETAILS)) {
+            return;
+        }
+
+        grantMandatoryQuestionRepository.findBySubmissionId(submission.getId())
+                .filter(mandatoryQuestion -> mandatoryQuestion.getStatus() != GrantMandatoryQuestionStatus.COMPLETED)
+                .ifPresent(mandatoryQuestion -> {
+                    mandatoryQuestion.setStatus(GrantMandatoryQuestionStatus.COMPLETED);
+                    if (mandatoryQuestion.getGapId() == null || mandatoryQuestion.getGapId().isBlank()) {
+                        mandatoryQuestion.setGapId(GapIdGenerator.generateGapId(
+                                submission.getApplicant().getId(),
+                                envProperties.getEnvironmentName(),
+                                grantMandatoryQuestionRepository.count(),
+                                submission.getScheme().getVersion()));
+                    }
+                    grantMandatoryQuestionRepository.save(mandatoryQuestion);
+                });
+    }
+
+    private boolean isSectionComplete(final Submission submission, final String sectionId) {
+        return submission.getDefinition().getSections().stream()
+                .filter(section -> section.getSectionId().equals(sectionId))
+                .findFirst()
+                .map(section -> section.getSectionStatus() == SubmissionSectionStatus.COMPLETED)
+                .orElse(false);
     }
 
     private boolean areAllMandatoryQuestionsAnswered(final SubmissionSection section) {

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsController.java
@@ -77,22 +77,6 @@ public class GrantMandatoryQuestionsController {
         return ResponseEntity.ok(getGrantMandatoryQuestionDto);
     }
 
-    @PostMapping("/new-submission/{submissionId}")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Grant Mandatory question created for submission", content = @Content(mediaType = "application/json", schema = @Schema(implementation = GetGrantMandatoryQuestionDto.class))),
-            @ApiResponse(responseCode = "404", description = "No submission found", content = @Content(mediaType = "application/json")),
-    })
-    public ResponseEntity<GetGrantMandatoryQuestionDto> createMandatoryQuestionForNewSubmission(@PathVariable final UUID submissionId) {
-        final JwtPayload jwtPayload = (JwtPayload) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-        final GrantMandatoryQuestions grantMandatoryQuestions = grantMandatoryQuestionService
-                .createMandatoryQuestionForNewSubmission(submissionId, jwtPayload.getSub());
-        log.info("Mandatory question with ID {} has been created for submission {}.", grantMandatoryQuestions.getId(), submissionId);
-
-        final GetGrantMandatoryQuestionDto getGrantMandatoryQuestionDto = grantMandatoryQuestionMapper.mapGrantMandatoryQuestionToGetGrantMandatoryQuestionDTO(grantMandatoryQuestions);
-        return ResponseEntity.ok(getGrantMandatoryQuestionDto);
-    }
-
     @PostMapping("/ensure-mandatory-question/{submissionId}")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Grant Mandatory question for submission ensured", content = @Content(mediaType = "application/json", schema = @Schema(implementation = GetGrantMandatoryQuestionDto.class))),

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsController.java
@@ -93,6 +93,22 @@ public class GrantMandatoryQuestionsController {
         return ResponseEntity.ok(getGrantMandatoryQuestionDto);
     }
 
+    @PostMapping("/ensure-mandatory-question/{submissionId}")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Grant Mandatory question for submission ensured", content = @Content(mediaType = "application/json", schema = @Schema(implementation = GetGrantMandatoryQuestionDto.class))),
+            @ApiResponse(responseCode = "404", description = "No submission found", content = @Content(mediaType = "application/json")),
+    })
+    public ResponseEntity<GetGrantMandatoryQuestionDto> ensureMandatoryQuestionForSubmission(@PathVariable final UUID submissionId) {
+        final JwtPayload jwtPayload = (JwtPayload) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        final GrantMandatoryQuestions grantMandatoryQuestions = grantMandatoryQuestionService
+                .ensureMandatoryQuestionForSubmission(submissionId, jwtPayload.getSub());
+        log.info("Mandatory question with ID {} is linked to submission {}.", grantMandatoryQuestions.getId(), submissionId);
+
+        final GetGrantMandatoryQuestionDto getGrantMandatoryQuestionDto = grantMandatoryQuestionMapper.mapGrantMandatoryQuestionToGetGrantMandatoryQuestionDTO(grantMandatoryQuestions);
+        return ResponseEntity.ok(getGrantMandatoryQuestionDto);
+    }
+
     @GetMapping("/{mandatoryQuestionId}")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Grant Mandatory found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = GrantMandatoryQuestions.class))),

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsController.java
@@ -77,6 +77,22 @@ public class GrantMandatoryQuestionsController {
         return ResponseEntity.ok(getGrantMandatoryQuestionDto);
     }
 
+    @PostMapping("/new-submission/{submissionId}")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Grant Mandatory question created for submission", content = @Content(mediaType = "application/json", schema = @Schema(implementation = GetGrantMandatoryQuestionDto.class))),
+            @ApiResponse(responseCode = "404", description = "No submission found", content = @Content(mediaType = "application/json")),
+    })
+    public ResponseEntity<GetGrantMandatoryQuestionDto> createMandatoryQuestionForNewSubmission(@PathVariable final UUID submissionId) {
+        final JwtPayload jwtPayload = (JwtPayload) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        final GrantMandatoryQuestions grantMandatoryQuestions = grantMandatoryQuestionService
+                .createMandatoryQuestionForNewSubmission(submissionId, jwtPayload.getSub());
+        log.info("Mandatory question with ID {} has been created for submission {}.", grantMandatoryQuestions.getId(), submissionId);
+
+        final GetGrantMandatoryQuestionDto getGrantMandatoryQuestionDto = grantMandatoryQuestionMapper.mapGrantMandatoryQuestionToGetGrantMandatoryQuestionDTO(grantMandatoryQuestions);
+        return ResponseEntity.ok(getGrantMandatoryQuestionDto);
+    }
+
     @GetMapping("/{mandatoryQuestionId}")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Grant Mandatory found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = GrantMandatoryQuestions.class))),

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/SubmissionController.java
@@ -221,6 +221,13 @@ public class SubmissionController {
         final Submission submission = submissionService.getSubmissionFromDatabaseBySubmissionId(grantApplicant.getUserId(), applicationSubmission.getSubmissionId());
         final GrantScheme scheme = submission.getScheme();
 
+        // Backstop heal: guarantee this submission owns its own mandatory question before it is finalised. If it was
+        // relying on a sibling submission's record, this creates its own and blanks the funding details, so the
+        // readiness check inside submit() rejects it until funding is re-entered. This closes the gap where a direct
+        // POST to /submit bypasses the heal performed on the application pages. No-op when the submission already
+        // owns its mandatory question.
+        mandatoryQuestionService.ensureMandatoryQuestionForSubmission(submission.getId(), grantApplicant.getUserId());
+
         submissionService.submit(submission, grantApplicant, jwtPayload.getEmail());
 
         if (scheme.getVersion() > 1) {

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/web/controlleradvice/ControllerExceptionHandler.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/web/controlleradvice/ControllerExceptionHandler.java
@@ -150,6 +150,20 @@ public class ControllerExceptionHandler {
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(SectionNotReadyException.class)
+    public ErrorResponseBody handleSectionNotReady(SectionNotReadyException ex) {
+        log.error("SectionNotReadyException thrown: {}", ex.getMessage());
+        return ErrorResponseBody.builder()
+                .responseAccepted(Boolean.FALSE)
+                .message("Validation failure")
+                .errors(List.of(Error.builder()
+                        .fieldName("isComplete")
+                        .errorMessage(ex.getMessage())
+                        .build()))
+                .build();
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler({
             SubmissionNotReadyException.class,
     })

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
@@ -462,6 +462,7 @@ class GrantMandatoryQuestionServiceTest {
                     .status(status)
                     .scheme(scheme)
                     .applicant(applicant)
+                    .mandatorySectionsCompleted(true)
                     .build();
         }
 
@@ -538,6 +539,9 @@ class GrantMandatoryQuestionServiceTest {
             assertThat(fundingSection.getQuestions().stream()
                     .filter(question -> "APPLICANT_AMOUNT".equals(question.getQuestionId()))
                     .findFirst().orElseThrow().getResponse()).isNull();
+
+            // Blanking funding clears the submission's cached "mandatory sections completed" flag
+            assertThat(submission.getMandatorySectionsCompleted()).isFalse();
         }
 
         @Test

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
@@ -407,9 +407,9 @@ class GrantMandatoryQuestionServiceTest {
     }
 
     @Nested
-    class createMandatoryQuestionForNewSubmission {
+    class ensureMandatoryQuestionForSubmission {
 
-        private Submission buildVersionTwoSubmission(final UUID submissionId, final GrantScheme scheme, final GrantApplicant applicant) {
+        private Submission buildNewSubmissionWithoutOrgInDefinition(final UUID submissionId, final GrantScheme scheme, final GrantApplicant applicant) {
             final SubmissionDefinition definition = SubmissionDefinition.builder()
                     .sections(new ArrayList<>(List.of(
                             SubmissionSection.builder().sectionId("ELIGIBILITY").build(),
@@ -426,150 +426,6 @@ class GrantMandatoryQuestionServiceTest {
                     .build();
         }
 
-        @Test
-        void copiesOrgDetailsButBlanksFunding_AndProjectsIntoSubmission() {
-            final UUID submissionId = UUID.randomUUID();
-            final GrantScheme scheme = GrantScheme.builder().id(10).version(2).build();
-            final GrantApplicant applicant = GrantApplicant.builder().id(1L).userId(applicantUserId).build();
-            final Submission submission = buildVersionTwoSubmission(submissionId, scheme, applicant);
-
-            final GrantMandatoryQuestions source = GrantMandatoryQuestions.builder()
-                    .name("AND Digital")
-                    .addressLine1("215 Bothwell Street")
-                    .addressLine2("Floor 2")
-                    .city("Glasgow")
-                    .county("Lanarkshire")
-                    .postcode("G2 7EZ")
-                    .orgType(GrantMandatoryQuestionOrgType.LIMITED_COMPANY)
-                    .companiesHouseNumber("1234567")
-                    .charityCommissionNumber("22135")
-                    .fundingAmount(BigDecimal.valueOf(150000))
-                    .fundingLocation(new GrantMandatoryQuestionFundingLocation[]{
-                            GrantMandatoryQuestionFundingLocation.SCOTLAND
-                    })
-                    .gapId("GAP-LL-20240101-1")
-                    .build();
-
-            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
-                    .thenReturn(Optional.of(submission));
-            when(grantMandatoryQuestionRepository.findBySubmissionId(submissionId))
-                    .thenReturn(Optional.empty());
-            when(grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(scheme.getId(), applicantUserId))
-                    .thenReturn(Optional.of(source));
-            when(grantMandatoryQuestionRepository.save(Mockito.any()))
-                    .thenAnswer(invocation -> invocation.getArgument(0));
-
-            final GrantMandatoryQuestions result = serviceUnderTest.createMandatoryQuestionForNewSubmission(submissionId, applicantUserId);
-
-            // Organisation/address details are copied from the most recent MQ
-            assertThat(result.getName()).isEqualTo("AND Digital");
-            assertThat(result.getAddressLine1()).isEqualTo("215 Bothwell Street");
-            assertThat(result.getAddressLine2()).isEqualTo("Floor 2");
-            assertThat(result.getCity()).isEqualTo("Glasgow");
-            assertThat(result.getCounty()).isEqualTo("Lanarkshire");
-            assertThat(result.getPostcode()).isEqualTo("G2 7EZ");
-            assertThat(result.getOrgType()).isEqualTo(GrantMandatoryQuestionOrgType.LIMITED_COMPANY);
-            assertThat(result.getCompaniesHouseNumber()).isEqualTo("1234567");
-            assertThat(result.getCharityCommissionNumber()).isEqualTo("22135");
-
-            // Funding + gapId are deliberately blanked for the new submission
-            assertThat(result.getFundingAmount()).isNull();
-            assertThat(result.getFundingLocation()).isNull();
-            assertThat(result.getGapId()).isNull();
-
-            // Linked to the new submission and set in progress
-            assertThat(result.getStatus()).isEqualTo(GrantMandatoryQuestionStatus.IN_PROGRESS);
-            assertThat(result.getSubmission()).isEqualTo(submission);
-            assertThat(result.getGrantScheme()).isEqualTo(scheme);
-            assertThat(result.getCreatedBy()).isEqualTo(applicant);
-
-            // The new MQ is saved and projected into its own submission
-            verify(grantMandatoryQuestionRepository).save(Mockito.any());
-            verify(submissionRepository).save(submission);
-            verify(serviceUnderTest).addMandatoryQuestionsToSubmissionObject(result);
-        }
-
-        @Test
-        void fallsBackToOrgProfile_WhenNoPreviousMandatoryQuestionExists() {
-            final UUID submissionId = UUID.randomUUID();
-            final GrantScheme scheme = GrantScheme.builder().id(10).version(2).build();
-            final GrantApplicant applicant = GrantApplicant.builder()
-                    .id(1L)
-                    .userId(applicantUserId)
-                    .organisationProfile(organisationProfile)
-                    .build();
-            final Submission submission = buildVersionTwoSubmission(submissionId, scheme, applicant);
-
-            final GrantMandatoryQuestions fromProfile = GrantMandatoryQuestions.builder()
-                    .name(organisationProfile.getLegalName())
-                    .addressLine1(organisationProfile.getAddressLine1())
-                    .city(organisationProfile.getTown())
-                    .postcode(organisationProfile.getPostcode())
-                    .orgType(GrantMandatoryQuestionOrgType.LIMITED_COMPANY)
-                    .build();
-
-            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
-                    .thenReturn(Optional.of(submission));
-            when(grantMandatoryQuestionRepository.findBySubmissionId(submissionId))
-                    .thenReturn(Optional.empty());
-            when(grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(scheme.getId(), applicantUserId))
-                    .thenReturn(Optional.empty());
-            when(organisationProfileMapper.mapOrgProfileToGrantMandatoryQuestion(organisationProfile))
-                    .thenReturn(fromProfile);
-            when(grantMandatoryQuestionRepository.save(Mockito.any()))
-                    .thenAnswer(invocation -> invocation.getArgument(0));
-
-            final GrantMandatoryQuestions result = serviceUnderTest.createMandatoryQuestionForNewSubmission(submissionId, applicantUserId);
-
-            verify(organisationProfileMapper).mapOrgProfileToGrantMandatoryQuestion(organisationProfile);
-            assertThat(result.getName()).isEqualTo(organisationProfile.getLegalName());
-            assertThat(result.getFundingAmount()).isNull();
-            assertThat(result.getFundingLocation()).isNull();
-            assertThat(result.getSubmission()).isEqualTo(submission);
-        }
-
-        @Test
-        void isIdempotent_ReturnsExistingMandatoryQuestionForSubmission() {
-            final UUID submissionId = UUID.randomUUID();
-            final GrantScheme scheme = GrantScheme.builder().id(10).version(2).build();
-            final GrantApplicant applicant = GrantApplicant.builder().id(1L).userId(applicantUserId).build();
-            final Submission submission = buildVersionTwoSubmission(submissionId, scheme, applicant);
-
-            final GrantMandatoryQuestions existing = GrantMandatoryQuestions.builder()
-                    .id(UUID.randomUUID())
-                    .submission(submission)
-                    .build();
-
-            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
-                    .thenReturn(Optional.of(submission));
-            when(grantMandatoryQuestionRepository.findBySubmissionId(submissionId))
-                    .thenReturn(Optional.of(existing));
-
-            final GrantMandatoryQuestions result = serviceUnderTest.createMandatoryQuestionForNewSubmission(submissionId, applicantUserId);
-
-            assertThat(result).isEqualTo(existing);
-            verify(grantMandatoryQuestionRepository, never()).save(Mockito.any());
-            verify(grantMandatoryQuestionRepository, never())
-                    .findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(Mockito.anyInt(), Mockito.anyString());
-        }
-
-        @Test
-        void throwsNotFound_WhenSubmissionDoesNotExistForApplicant() {
-            final UUID submissionId = UUID.randomUUID();
-
-            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
-                    .thenReturn(Optional.empty());
-
-            assertThrows(NotFoundException.class,
-                    () -> serviceUnderTest.createMandatoryQuestionForNewSubmission(submissionId, applicantUserId));
-
-            verify(grantMandatoryQuestionRepository, never()).save(Mockito.any());
-        }
-    }
-
-    @Nested
-    class ensureMandatoryQuestionForSubmission {
-
         private Submission buildBrokenSiblingSubmission(final UUID submissionId, final GrantScheme scheme,
                 final GrantApplicant applicant, final SubmissionStatus status) {
             final SubmissionSection organisationDetails = SubmissionSection.builder()
@@ -585,6 +441,7 @@ class GrantMandatoryQuestionServiceTest {
                     .build();
             final SubmissionSection fundingDetails = SubmissionSection.builder()
                     .sectionId("FUNDING_DETAILS")
+                    .sectionStatus(SubmissionSectionStatus.COMPLETED)
                     .questions(new ArrayList<>(List.of(
                             SubmissionQuestion.builder().questionId("APPLICANT_AMOUNT").response("150000").build(),
                             SubmissionQuestion.builder().questionId("BENEFITIARY_LOCATION")
@@ -740,6 +597,103 @@ class GrantMandatoryQuestionServiceTest {
                     () -> serviceUnderTest.ensureMandatoryQuestionForSubmission(submissionId, applicantUserId));
 
             verify(grantMandatoryQuestionRepository, never()).save(Mockito.any());
+        }
+
+        @Test
+        void seedsOrgFromMostRecentMandatoryQuestion_WhenSubmissionDefinitionHasNoOrg() {
+            final UUID submissionId = UUID.randomUUID();
+            final GrantScheme scheme = GrantScheme.builder().id(10).version(2).build();
+            final GrantApplicant applicant = GrantApplicant.builder().id(1L).userId(applicantUserId).build();
+            final Submission submission = buildNewSubmissionWithoutOrgInDefinition(submissionId, scheme, applicant);
+
+            final GrantMandatoryQuestions source = GrantMandatoryQuestions.builder()
+                    .name("AND Digital")
+                    .addressLine1("215 Bothwell Street")
+                    .addressLine2("Floor 2")
+                    .city("Glasgow")
+                    .county("Lanarkshire")
+                    .postcode("G2 7EZ")
+                    .orgType(GrantMandatoryQuestionOrgType.LIMITED_COMPANY)
+                    .companiesHouseNumber("1234567")
+                    .charityCommissionNumber("22135")
+                    .fundingAmount(BigDecimal.valueOf(150000))
+                    .fundingLocation(new GrantMandatoryQuestionFundingLocation[]{
+                            GrantMandatoryQuestionFundingLocation.SCOTLAND
+                    })
+                    .gapId("GAP-LL-20240101-1")
+                    .build();
+
+            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
+                    .thenReturn(Optional.of(submission));
+            when(grantMandatoryQuestionRepository.findBySubmissionId(submissionId))
+                    .thenReturn(Optional.empty());
+            when(grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(scheme.getId(), applicantUserId))
+                    .thenReturn(Optional.of(source));
+            when(grantMandatoryQuestionRepository.save(Mockito.any()))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            final GrantMandatoryQuestions result = serviceUnderTest.ensureMandatoryQuestionForSubmission(submissionId, applicantUserId);
+
+            // Organisation/address details are seeded from the applicant's most recent MQ (the definition had none)
+            assertThat(result.getName()).isEqualTo("AND Digital");
+            assertThat(result.getAddressLine1()).isEqualTo("215 Bothwell Street");
+            assertThat(result.getOrgType()).isEqualTo(GrantMandatoryQuestionOrgType.LIMITED_COMPANY);
+            assertThat(result.getCompaniesHouseNumber()).isEqualTo("1234567");
+            assertThat(result.getCharityCommissionNumber()).isEqualTo("22135");
+
+            // Funding + gapId are deliberately blanked for the new submission
+            assertThat(result.getFundingAmount()).isNull();
+            assertThat(result.getFundingLocation()).isNull();
+            assertThat(result.getGapId()).isNull();
+
+            assertThat(result.getStatus()).isEqualTo(GrantMandatoryQuestionStatus.IN_PROGRESS);
+            assertThat(result.getSubmission()).isEqualTo(submission);
+            assertThat(result.getGrantScheme()).isEqualTo(scheme);
+            assertThat(result.getCreatedBy()).isEqualTo(applicant);
+
+            verify(grantMandatoryQuestionRepository).save(Mockito.any());
+            verify(submissionRepository).save(submission);
+            verify(serviceUnderTest).addMandatoryQuestionsToSubmissionObject(result);
+        }
+
+        @Test
+        void fallsBackToOrgProfile_WhenNoOrgInDefinitionAndNoPreviousMandatoryQuestion() {
+            final UUID submissionId = UUID.randomUUID();
+            final GrantScheme scheme = GrantScheme.builder().id(10).version(2).build();
+            final GrantApplicant applicant = GrantApplicant.builder()
+                    .id(1L)
+                    .userId(applicantUserId)
+                    .organisationProfile(organisationProfile)
+                    .build();
+            final Submission submission = buildNewSubmissionWithoutOrgInDefinition(submissionId, scheme, applicant);
+
+            final GrantMandatoryQuestions fromProfile = GrantMandatoryQuestions.builder()
+                    .name(organisationProfile.getLegalName())
+                    .addressLine1(organisationProfile.getAddressLine1())
+                    .city(organisationProfile.getTown())
+                    .postcode(organisationProfile.getPostcode())
+                    .orgType(GrantMandatoryQuestionOrgType.LIMITED_COMPANY)
+                    .build();
+
+            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
+                    .thenReturn(Optional.of(submission));
+            when(grantMandatoryQuestionRepository.findBySubmissionId(submissionId))
+                    .thenReturn(Optional.empty());
+            when(grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(scheme.getId(), applicantUserId))
+                    .thenReturn(Optional.empty());
+            when(organisationProfileMapper.mapOrgProfileToGrantMandatoryQuestion(organisationProfile))
+                    .thenReturn(fromProfile);
+            when(grantMandatoryQuestionRepository.save(Mockito.any()))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            final GrantMandatoryQuestions result = serviceUnderTest.ensureMandatoryQuestionForSubmission(submissionId, applicantUserId);
+
+            verify(organisationProfileMapper).mapOrgProfileToGrantMandatoryQuestion(organisationProfile);
+            assertThat(result.getName()).isEqualTo(organisationProfile.getLegalName());
+            assertThat(result.getOrgType()).isEqualTo(GrantMandatoryQuestionOrgType.LIMITED_COMPANY);
+            assertThat(result.getFundingAmount()).isNull();
+            assertThat(result.getFundingLocation()).isNull();
+            assertThat(result.getSubmission()).isEqualTo(submission);
         }
     }
 

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
@@ -568,6 +568,171 @@ class GrantMandatoryQuestionServiceTest {
     }
 
     @Nested
+    class ensureMandatoryQuestionForSubmission {
+
+        private Submission buildBrokenSiblingSubmission(final UUID submissionId, final GrantScheme scheme,
+                final GrantApplicant applicant, final SubmissionStatus status) {
+            final SubmissionSection organisationDetails = SubmissionSection.builder()
+                    .sectionId("ORGANISATION_DETAILS")
+                    .questions(new ArrayList<>(List.of(
+                            SubmissionQuestion.builder().questionId("APPLICANT_TYPE").response("Limited company").build(),
+                            SubmissionQuestion.builder().questionId("APPLICANT_ORG_NAME").response("AND Digital").build(),
+                            SubmissionQuestion.builder().questionId("APPLICANT_ORG_ADDRESS")
+                                    .multiResponse(new String[]{"215 Bothwell Street", "Floor 2", "Glasgow", "Lanarkshire", "G2 7EZ"}).build(),
+                            SubmissionQuestion.builder().questionId("APPLICANT_ORG_COMPANIES_HOUSE").response("1234567").build(),
+                            SubmissionQuestion.builder().questionId("APPLICANT_ORG_CHARITY_NUMBER").response("22135").build()
+                    )))
+                    .build();
+            final SubmissionSection fundingDetails = SubmissionSection.builder()
+                    .sectionId("FUNDING_DETAILS")
+                    .questions(new ArrayList<>(List.of(
+                            SubmissionQuestion.builder().questionId("APPLICANT_AMOUNT").response("150000").build(),
+                            SubmissionQuestion.builder().questionId("BENEFITIARY_LOCATION")
+                                    .multiResponse(new String[]{"Scotland", "Wales"}).build()
+                    )))
+                    .build();
+            final SubmissionDefinition definition = SubmissionDefinition.builder()
+                    .sections(new ArrayList<>(List.of(
+                            SubmissionSection.builder().sectionId("ELIGIBILITY").build(),
+                            organisationDetails,
+                            fundingDetails
+                    )))
+                    .build();
+            return Submission.builder()
+                    .id(submissionId)
+                    .definition(definition)
+                    .version(2)
+                    .status(status)
+                    .scheme(scheme)
+                    .applicant(applicant)
+                    .build();
+        }
+
+        @Test
+        void returnsExistingMandatoryQuestion_WhenSubmissionAlreadyOwnsOne() {
+            final UUID submissionId = UUID.randomUUID();
+            final GrantScheme scheme = GrantScheme.builder().id(10).version(2).build();
+            final GrantApplicant applicant = GrantApplicant.builder().id(1L).userId(applicantUserId).build();
+            final Submission submission = buildBrokenSiblingSubmission(submissionId, scheme, applicant, SubmissionStatus.IN_PROGRESS);
+
+            final GrantMandatoryQuestions existing = GrantMandatoryQuestions.builder()
+                    .id(UUID.randomUUID())
+                    .submission(submission)
+                    .build();
+
+            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
+                    .thenReturn(Optional.of(submission));
+            when(grantMandatoryQuestionRepository.findBySubmissionId(submissionId))
+                    .thenReturn(Optional.of(existing));
+
+            final GrantMandatoryQuestions result = serviceUnderTest.ensureMandatoryQuestionForSubmission(submissionId, applicantUserId);
+
+            assertThat(result).isEqualTo(existing);
+            verify(grantMandatoryQuestionRepository, never()).save(Mockito.any());
+        }
+
+        @Test
+        void createsPerSubmissionMandatoryQuestionSeededFromDefinition_WhenNoneExists() {
+            final UUID submissionId = UUID.randomUUID();
+            final GrantScheme scheme = GrantScheme.builder().id(10).version(2).build();
+            final GrantApplicant applicant = GrantApplicant.builder().id(1L).userId(applicantUserId).build();
+            final Submission submission = buildBrokenSiblingSubmission(submissionId, scheme, applicant, SubmissionStatus.IN_PROGRESS);
+
+            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
+                    .thenReturn(Optional.of(submission));
+            when(grantMandatoryQuestionRepository.findBySubmissionId(submissionId))
+                    .thenReturn(Optional.empty());
+            when(grantMandatoryQuestionRepository.save(Mockito.any()))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            final GrantMandatoryQuestions result = serviceUnderTest.ensureMandatoryQuestionForSubmission(submissionId, applicantUserId);
+
+            // Organisation + funding details are seeded from the submission's own definition (its source of truth)
+            assertThat(result.getOrgType()).isEqualTo(GrantMandatoryQuestionOrgType.LIMITED_COMPANY);
+            assertThat(result.getName()).isEqualTo("AND Digital");
+            assertThat(result.getAddressLine1()).isEqualTo("215 Bothwell Street");
+            assertThat(result.getAddressLine2()).isEqualTo("Floor 2");
+            assertThat(result.getCity()).isEqualTo("Glasgow");
+            assertThat(result.getCounty()).isEqualTo("Lanarkshire");
+            assertThat(result.getPostcode()).isEqualTo("G2 7EZ");
+            assertThat(result.getCompaniesHouseNumber()).isEqualTo("1234567");
+            assertThat(result.getCharityCommissionNumber()).isEqualTo("22135");
+            assertThat(result.getFundingAmount()).isEqualByComparingTo(BigDecimal.valueOf(150000));
+            assertThat(result.getFundingLocation()).containsExactly(
+                    GrantMandatoryQuestionFundingLocation.SCOTLAND,
+                    GrantMandatoryQuestionFundingLocation.WALES);
+
+            // Linked to this submission, set in progress, with a fresh (null) gapId
+            assertThat(result.getSubmission()).isEqualTo(submission);
+            assertThat(result.getGrantScheme()).isEqualTo(scheme);
+            assertThat(result.getCreatedBy()).isEqualTo(applicant);
+            assertThat(result.getStatus()).isEqualTo(GrantMandatoryQuestionStatus.IN_PROGRESS);
+            assertThat(result.getGapId()).isNull();
+
+            verify(grantMandatoryQuestionRepository).save(Mockito.any());
+        }
+
+        @Test
+        void doesNotRePointSharedMandatoryQuestion_WhenHealingSibling() {
+            final UUID submissionId = UUID.randomUUID();
+            final GrantScheme scheme = GrantScheme.builder().id(10).version(2).build();
+            final GrantApplicant applicant = GrantApplicant.builder().id(1L).userId(applicantUserId).build();
+            final Submission submission = buildBrokenSiblingSubmission(submissionId, scheme, applicant, SubmissionStatus.IN_PROGRESS);
+
+            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
+                    .thenReturn(Optional.of(submission));
+            when(grantMandatoryQuestionRepository.findBySubmissionId(submissionId))
+                    .thenReturn(Optional.empty());
+            when(grantMandatoryQuestionRepository.save(Mockito.any()))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            serviceUnderTest.ensureMandatoryQuestionForSubmission(submissionId, applicantUserId);
+
+            // Only the freshly created per-submission record is saved - no shared record is fetched or re-pointed.
+            verify(grantMandatoryQuestionRepository, never())
+                    .findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(Mockito.anyInt(), Mockito.anyString());
+        }
+
+        @Test
+        void doesNotCreate_WhenSubmissionAlreadySubmitted() {
+            final UUID submissionId = UUID.randomUUID();
+            final GrantScheme scheme = GrantScheme.builder().id(10).version(2).build();
+            final GrantApplicant applicant = GrantApplicant.builder().id(1L).userId(applicantUserId).build();
+            final Submission submission = buildBrokenSiblingSubmission(submissionId, scheme, applicant, SubmissionStatus.SUBMITTED);
+
+            final GrantMandatoryQuestions resolved = GrantMandatoryQuestions.builder()
+                    .id(UUID.randomUUID())
+                    .createdBy(applicant)
+                    .build();
+
+            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
+                    .thenReturn(Optional.of(submission));
+            when(grantMandatoryQuestionRepository.findBySubmissionId(submissionId))
+                    .thenReturn(Optional.empty());
+            doReturn(resolved).when(serviceUnderTest)
+                    .getGrantMandatoryQuestionBySubmissionIdAndApplicantSub(submissionId, applicantUserId);
+
+            final GrantMandatoryQuestions result = serviceUnderTest.ensureMandatoryQuestionForSubmission(submissionId, applicantUserId);
+
+            assertThat(result).isEqualTo(resolved);
+            verify(grantMandatoryQuestionRepository, never()).save(Mockito.any());
+        }
+
+        @Test
+        void throwsNotFound_WhenSubmissionDoesNotExistForApplicant() {
+            final UUID submissionId = UUID.randomUUID();
+
+            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
+                    .thenReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class,
+                    () -> serviceUnderTest.ensureMandatoryQuestionForSubmission(submissionId, applicantUserId));
+
+            verify(grantMandatoryQuestionRepository, never()).save(Mockito.any());
+        }
+    }
+
+    @Nested
     class updateMandatoryQuestions {
         @Test
         void updateMandatoryQuestion_ThrowsNotFoundException() {

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
@@ -195,7 +195,7 @@ class GrantMandatoryQuestionServiceTest {
 
             when(grantMandatoryQuestionRepository.findBySubmissionId(submissionId)).thenReturn(Optional.empty());
             when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId)).thenReturn(Optional.of(submission));
-            when(grantMandatoryQuestionRepository.findByGrantScheme_IdAndCreatedBy_UserId(schemeId, applicantUserId)).thenReturn(mandatoryQuestions);
+            when(grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(schemeId, applicantUserId)).thenReturn(mandatoryQuestions);
 
             final GrantMandatoryQuestions methodResponse = serviceUnderTest.getGrantMandatoryQuestionBySubmissionIdAndApplicantSub(submissionId, applicantUserId);
 
@@ -212,7 +212,7 @@ class GrantMandatoryQuestionServiceTest {
 
             when(grantMandatoryQuestionRepository.findBySubmissionId(submissionId)).thenReturn(Optional.empty());
             when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId)).thenReturn(Optional.of(submission));
-            when(grantMandatoryQuestionRepository.findByGrantScheme_IdAndCreatedBy_UserId(schemeId, applicantUserId)).thenReturn(Optional.empty());
+            when(grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(schemeId, applicantUserId)).thenReturn(Optional.empty());
 
             assertThrows(NotFoundException.class, () -> serviceUnderTest.getGrantMandatoryQuestionBySubmissionIdAndApplicantSub(submissionId, applicantUserId));
         }
@@ -224,7 +224,7 @@ class GrantMandatoryQuestionServiceTest {
         void getMandatoryQuestionByScheme_ThrowsNotFoundException() {
             final String applicantSub = "valid-applicant-id";
 
-            when(grantMandatoryQuestionRepository.findByGrantScheme_IdAndCreatedBy_UserId(1, applicantSub))
+            when(grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(1, applicantSub))
                     .thenReturn(Optional.empty());
 
             assertThrows(NotFoundException.class, () -> serviceUnderTest.getMandatoryQuestionBySchemeId(1, applicantSub));
@@ -237,7 +237,7 @@ class GrantMandatoryQuestionServiceTest {
             final GrantApplicant createdByOtherUser = GrantApplicant.builder().userId("other-user-id").build();
             final GrantMandatoryQuestions mandatoryQuestions = GrantMandatoryQuestions.builder().createdBy(createdByOtherUser).build();
 
-            when(grantMandatoryQuestionRepository.findByGrantScheme_IdAndCreatedBy_UserId(1, applicantSub))
+            when(grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(1, applicantSub))
                     .thenReturn(Optional.of(mandatoryQuestions));
 
             assertThrows(ForbiddenException.class, () -> serviceUnderTest.getMandatoryQuestionBySchemeId(1, applicantSub));
@@ -250,7 +250,7 @@ class GrantMandatoryQuestionServiceTest {
             final GrantApplicant createdByValidUser = GrantApplicant.builder().userId(applicantSub).build();
             final GrantMandatoryQuestions mandatoryQuestions = GrantMandatoryQuestions.builder().createdBy(createdByValidUser).build();
 
-            when(grantMandatoryQuestionRepository.findByGrantScheme_IdAndCreatedBy_UserId(1, applicantSub))
+            when(grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(1, applicantSub))
                     .thenReturn(Optional.of(mandatoryQuestions));
 
             final GrantMandatoryQuestions methodResponse = serviceUnderTest.getMandatoryQuestionBySchemeId(1, applicantSub);
@@ -404,6 +404,167 @@ class GrantMandatoryQuestionServiceTest {
             assertThat(methodResponse.getCompaniesHouseNumber()).isNull();
         }
 
+    }
+
+    @Nested
+    class createMandatoryQuestionForNewSubmission {
+
+        private Submission buildVersionTwoSubmission(final UUID submissionId, final GrantScheme scheme, final GrantApplicant applicant) {
+            final SubmissionDefinition definition = SubmissionDefinition.builder()
+                    .sections(new ArrayList<>(List.of(
+                            SubmissionSection.builder().sectionId("ELIGIBILITY").build(),
+                            SubmissionSection.builder().sectionId("ORGANISATION_DETAILS").build(),
+                            SubmissionSection.builder().sectionId("FUNDING_DETAILS").build()
+                    )))
+                    .build();
+            return Submission.builder()
+                    .id(submissionId)
+                    .definition(definition)
+                    .version(2)
+                    .scheme(scheme)
+                    .applicant(applicant)
+                    .build();
+        }
+
+        @Test
+        void copiesOrgDetailsButBlanksFunding_AndProjectsIntoSubmission() {
+            final UUID submissionId = UUID.randomUUID();
+            final GrantScheme scheme = GrantScheme.builder().id(10).version(2).build();
+            final GrantApplicant applicant = GrantApplicant.builder().id(1L).userId(applicantUserId).build();
+            final Submission submission = buildVersionTwoSubmission(submissionId, scheme, applicant);
+
+            final GrantMandatoryQuestions source = GrantMandatoryQuestions.builder()
+                    .name("AND Digital")
+                    .addressLine1("215 Bothwell Street")
+                    .addressLine2("Floor 2")
+                    .city("Glasgow")
+                    .county("Lanarkshire")
+                    .postcode("G2 7EZ")
+                    .orgType(GrantMandatoryQuestionOrgType.LIMITED_COMPANY)
+                    .companiesHouseNumber("1234567")
+                    .charityCommissionNumber("22135")
+                    .fundingAmount(BigDecimal.valueOf(150000))
+                    .fundingLocation(new GrantMandatoryQuestionFundingLocation[]{
+                            GrantMandatoryQuestionFundingLocation.SCOTLAND
+                    })
+                    .gapId("GAP-LL-20240101-1")
+                    .build();
+
+            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
+                    .thenReturn(Optional.of(submission));
+            when(grantMandatoryQuestionRepository.findBySubmissionId(submissionId))
+                    .thenReturn(Optional.empty());
+            when(grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(scheme.getId(), applicantUserId))
+                    .thenReturn(Optional.of(source));
+            when(grantMandatoryQuestionRepository.save(Mockito.any()))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            final GrantMandatoryQuestions result = serviceUnderTest.createMandatoryQuestionForNewSubmission(submissionId, applicantUserId);
+
+            // Organisation/address details are copied from the most recent MQ
+            assertThat(result.getName()).isEqualTo("AND Digital");
+            assertThat(result.getAddressLine1()).isEqualTo("215 Bothwell Street");
+            assertThat(result.getAddressLine2()).isEqualTo("Floor 2");
+            assertThat(result.getCity()).isEqualTo("Glasgow");
+            assertThat(result.getCounty()).isEqualTo("Lanarkshire");
+            assertThat(result.getPostcode()).isEqualTo("G2 7EZ");
+            assertThat(result.getOrgType()).isEqualTo(GrantMandatoryQuestionOrgType.LIMITED_COMPANY);
+            assertThat(result.getCompaniesHouseNumber()).isEqualTo("1234567");
+            assertThat(result.getCharityCommissionNumber()).isEqualTo("22135");
+
+            // Funding + gapId are deliberately blanked for the new submission
+            assertThat(result.getFundingAmount()).isNull();
+            assertThat(result.getFundingLocation()).isNull();
+            assertThat(result.getGapId()).isNull();
+
+            // Linked to the new submission and set in progress
+            assertThat(result.getStatus()).isEqualTo(GrantMandatoryQuestionStatus.IN_PROGRESS);
+            assertThat(result.getSubmission()).isEqualTo(submission);
+            assertThat(result.getGrantScheme()).isEqualTo(scheme);
+            assertThat(result.getCreatedBy()).isEqualTo(applicant);
+
+            // The new MQ is saved and projected into its own submission
+            verify(grantMandatoryQuestionRepository).save(Mockito.any());
+            verify(submissionRepository).save(submission);
+            verify(serviceUnderTest).addMandatoryQuestionsToSubmissionObject(result);
+        }
+
+        @Test
+        void fallsBackToOrgProfile_WhenNoPreviousMandatoryQuestionExists() {
+            final UUID submissionId = UUID.randomUUID();
+            final GrantScheme scheme = GrantScheme.builder().id(10).version(2).build();
+            final GrantApplicant applicant = GrantApplicant.builder()
+                    .id(1L)
+                    .userId(applicantUserId)
+                    .organisationProfile(organisationProfile)
+                    .build();
+            final Submission submission = buildVersionTwoSubmission(submissionId, scheme, applicant);
+
+            final GrantMandatoryQuestions fromProfile = GrantMandatoryQuestions.builder()
+                    .name(organisationProfile.getLegalName())
+                    .addressLine1(organisationProfile.getAddressLine1())
+                    .city(organisationProfile.getTown())
+                    .postcode(organisationProfile.getPostcode())
+                    .orgType(GrantMandatoryQuestionOrgType.LIMITED_COMPANY)
+                    .build();
+
+            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
+                    .thenReturn(Optional.of(submission));
+            when(grantMandatoryQuestionRepository.findBySubmissionId(submissionId))
+                    .thenReturn(Optional.empty());
+            when(grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(scheme.getId(), applicantUserId))
+                    .thenReturn(Optional.empty());
+            when(organisationProfileMapper.mapOrgProfileToGrantMandatoryQuestion(organisationProfile))
+                    .thenReturn(fromProfile);
+            when(grantMandatoryQuestionRepository.save(Mockito.any()))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            final GrantMandatoryQuestions result = serviceUnderTest.createMandatoryQuestionForNewSubmission(submissionId, applicantUserId);
+
+            verify(organisationProfileMapper).mapOrgProfileToGrantMandatoryQuestion(organisationProfile);
+            assertThat(result.getName()).isEqualTo(organisationProfile.getLegalName());
+            assertThat(result.getFundingAmount()).isNull();
+            assertThat(result.getFundingLocation()).isNull();
+            assertThat(result.getSubmission()).isEqualTo(submission);
+        }
+
+        @Test
+        void isIdempotent_ReturnsExistingMandatoryQuestionForSubmission() {
+            final UUID submissionId = UUID.randomUUID();
+            final GrantScheme scheme = GrantScheme.builder().id(10).version(2).build();
+            final GrantApplicant applicant = GrantApplicant.builder().id(1L).userId(applicantUserId).build();
+            final Submission submission = buildVersionTwoSubmission(submissionId, scheme, applicant);
+
+            final GrantMandatoryQuestions existing = GrantMandatoryQuestions.builder()
+                    .id(UUID.randomUUID())
+                    .submission(submission)
+                    .build();
+
+            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
+                    .thenReturn(Optional.of(submission));
+            when(grantMandatoryQuestionRepository.findBySubmissionId(submissionId))
+                    .thenReturn(Optional.of(existing));
+
+            final GrantMandatoryQuestions result = serviceUnderTest.createMandatoryQuestionForNewSubmission(submissionId, applicantUserId);
+
+            assertThat(result).isEqualTo(existing);
+            verify(grantMandatoryQuestionRepository, never()).save(Mockito.any());
+            verify(grantMandatoryQuestionRepository, never())
+                    .findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(Mockito.anyInt(), Mockito.anyString());
+        }
+
+        @Test
+        void throwsNotFound_WhenSubmissionDoesNotExistForApplicant() {
+            final UUID submissionId = UUID.randomUUID();
+
+            when(submissionRepository.findByIdAndApplicantUserId(submissionId, applicantUserId))
+                    .thenReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class,
+                    () -> serviceUnderTest.createMandatoryQuestionForNewSubmission(submissionId, applicantUserId));
+
+            verify(grantMandatoryQuestionRepository, never()).save(Mockito.any());
+        }
     }
 
     @Nested
@@ -724,7 +885,7 @@ class GrantMandatoryQuestionServiceTest {
         }
 
         @Test
-        void updatesAllSubmissionsForScheme_InMultiAppScheme() {
+        void doesNotPropagateToOtherSubmissionsForScheme_InMultiAppScheme() {
             final GrantApplicant applicant = GrantApplicant.builder().id(1L).build();
             final GrantScheme scheme = GrantScheme.builder().id(10).version(2).build();
 
@@ -772,19 +933,14 @@ class GrantMandatoryQuestionServiceTest {
                     .charityCommissionNumber("22135")
                     .build();
 
-            when(submissionRepository.findByApplicant_IdAndScheme_Id(applicant.getId(), scheme.getId()))
-                    .thenReturn(List.of(submission1, submission2));
-
             serviceUnderTest.addMandatoryQuestionsToSubmissionObject(mandatoryQuestions);
 
-            // Both submissions' sections should be rebuilt from the MQ
-            verify(serviceUnderTest, times(2)).buildOrganisationDetailsSubmissionSection(Mockito.any(), Mockito.any());
-            verify(serviceUnderTest, times(2)).buildFundingDetailsSubmissionSection(Mockito.any(), Mockito.any());
+            // Only the submission linked to the MQ is rebuilt; there is deliberately no propagation.
+            verify(serviceUnderTest, times(1)).buildOrganisationDetailsSubmissionSection(Mockito.any(), Mockito.any());
+            verify(serviceUnderTest, times(1)).buildFundingDetailsSubmissionSection(Mockito.any(), Mockito.any());
 
-            // submission2 (not linked to the MQ) must be saved explicitly
-            verify(submissionRepository).save(submission2);
-            // submission1 (linked to the MQ) is saved via cascade — must NOT be saved directly
-            verify(submissionRepository, never()).save(submission1);
+            // No other submission for the scheme is saved.
+            verify(submissionRepository, never()).save(submission2);
         }
     }
 

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
@@ -258,6 +258,56 @@ class GrantMandatoryQuestionServiceTest {
             assertThat(methodResponse).isEqualTo(mandatoryQuestions);
         }
 
+        @Test
+        void getMandatoryQuestionByScheme_PrefersMostRecentCompletedMandatoryQuestion() {
+            final String applicantSub = "valid-applicant-id";
+
+            final GrantApplicant createdByValidUser = GrantApplicant.builder().userId(applicantSub).build();
+            final GrantMandatoryQuestions completedMandatoryQuestion = GrantMandatoryQuestions.builder()
+                    .createdBy(createdByValidUser)
+                    .status(GrantMandatoryQuestionStatus.COMPLETED)
+                    .build();
+
+            when(grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdAndStatusOrderByCreatedDesc(
+                    1, applicantSub, GrantMandatoryQuestionStatus.COMPLETED))
+                    .thenReturn(Optional.of(completedMandatoryQuestion));
+
+            final GrantMandatoryQuestions methodResponse = serviceUnderTest.getMandatoryQuestionBySchemeId(1, applicantSub);
+
+            assertThat(methodResponse).isEqualTo(completedMandatoryQuestion);
+            // A completed MQ wins outright: the submission-linked and most-recent-overall lookups must not be reached.
+            verify(grantMandatoryQuestionRepository, never())
+                    .findFirstByGrantScheme_IdAndCreatedBy_UserIdAndSubmissionIsNotNullOrderByCreatedDesc(Mockito.anyInt(), Mockito.anyString());
+            verify(grantMandatoryQuestionRepository, never())
+                    .findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(Mockito.anyInt(), Mockito.anyString());
+        }
+
+        @Test
+        void getMandatoryQuestionByScheme_FallsBackToSubmissionLinkedWhenNoCompletedExists() {
+            final String applicantSub = "valid-applicant-id";
+
+            final GrantApplicant createdByValidUser = GrantApplicant.builder().userId(applicantSub).build();
+            final GrantMandatoryQuestions submissionLinkedMandatoryQuestion = GrantMandatoryQuestions.builder()
+                    .createdBy(createdByValidUser)
+                    .status(GrantMandatoryQuestionStatus.IN_PROGRESS)
+                    .submission(Submission.builder().build())
+                    .build();
+
+            when(grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdAndStatusOrderByCreatedDesc(
+                    1, applicantSub, GrantMandatoryQuestionStatus.COMPLETED))
+                    .thenReturn(Optional.empty());
+            when(grantMandatoryQuestionRepository.findFirstByGrantScheme_IdAndCreatedBy_UserIdAndSubmissionIsNotNullOrderByCreatedDesc(
+                    1, applicantSub))
+                    .thenReturn(Optional.of(submissionLinkedMandatoryQuestion));
+
+            final GrantMandatoryQuestions methodResponse = serviceUnderTest.getMandatoryQuestionBySchemeId(1, applicantSub);
+
+            assertThat(methodResponse).isEqualTo(submissionLinkedMandatoryQuestion);
+            // With no completed MQ but a submission-linked one, the most-recent-overall lookup must not be reached.
+            verify(grantMandatoryQuestionRepository, never())
+                    .findFirstByGrantScheme_IdAndCreatedBy_UserIdOrderByCreatedDesc(Mockito.anyInt(), Mockito.anyString());
+        }
+
     }
 
     @Nested

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/GrantMandatoryQuestionServiceTest.java
@@ -632,7 +632,7 @@ class GrantMandatoryQuestionServiceTest {
         }
 
         @Test
-        void createsPerSubmissionMandatoryQuestionSeededFromDefinition_WhenNoneExists() {
+        void createsPerSubmissionMandatoryQuestion_SeedsOrgButBlanksFunding_WhenNoneExists() {
             final UUID submissionId = UUID.randomUUID();
             final GrantScheme scheme = GrantScheme.builder().id(10).version(2).build();
             final GrantApplicant applicant = GrantApplicant.builder().id(1L).userId(applicantUserId).build();
@@ -647,7 +647,7 @@ class GrantMandatoryQuestionServiceTest {
 
             final GrantMandatoryQuestions result = serviceUnderTest.ensureMandatoryQuestionForSubmission(submissionId, applicantUserId);
 
-            // Organisation + funding details are seeded from the submission's own definition (its source of truth)
+            // Organisation details are seeded from the submission's own definition (its source of truth)
             assertThat(result.getOrgType()).isEqualTo(GrantMandatoryQuestionOrgType.LIMITED_COMPANY);
             assertThat(result.getName()).isEqualTo("AND Digital");
             assertThat(result.getAddressLine1()).isEqualTo("215 Bothwell Street");
@@ -657,10 +657,10 @@ class GrantMandatoryQuestionServiceTest {
             assertThat(result.getPostcode()).isEqualTo("G2 7EZ");
             assertThat(result.getCompaniesHouseNumber()).isEqualTo("1234567");
             assertThat(result.getCharityCommissionNumber()).isEqualTo("22135");
-            assertThat(result.getFundingAmount()).isEqualByComparingTo(BigDecimal.valueOf(150000));
-            assertThat(result.getFundingLocation()).containsExactly(
-                    GrantMandatoryQuestionFundingLocation.SCOTLAND,
-                    GrantMandatoryQuestionFundingLocation.WALES);
+
+            // Funding is deliberately blanked so the applicant must re-confirm it for this submission
+            assertThat(result.getFundingAmount()).isNull();
+            assertThat(result.getFundingLocation()).isNull();
 
             // Linked to this submission, set in progress, with a fresh (null) gapId
             assertThat(result.getSubmission()).isEqualTo(submission);
@@ -669,7 +669,18 @@ class GrantMandatoryQuestionServiceTest {
             assertThat(result.getStatus()).isEqualTo(GrantMandatoryQuestionStatus.IN_PROGRESS);
             assertThat(result.getGapId()).isNull();
 
+            // The blanked funding is projected into this submission and its funding section is reopened
             verify(grantMandatoryQuestionRepository).save(Mockito.any());
+            verify(serviceUnderTest).addMandatoryQuestionsToSubmissionObject(result);
+            verify(submissionRepository).save(submission);
+
+            final SubmissionSection fundingSection = submission.getDefinition().getSections().stream()
+                    .filter(section -> "FUNDING_DETAILS".equals(section.getSectionId()))
+                    .findFirst().orElseThrow();
+            assertThat(fundingSection.getSectionStatus()).isEqualTo(SubmissionSectionStatus.IN_PROGRESS);
+            assertThat(fundingSection.getQuestions().stream()
+                    .filter(question -> "APPLICANT_AMOUNT".equals(question.getQuestionId()))
+                    .findFirst().orElseThrow().getResponse()).isNull();
         }
 
         @Test

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
@@ -8,6 +8,7 @@ import gov.cabinetoffice.gap.applybackend.dto.api.CreateQuestionResponseDto;
 import gov.cabinetoffice.gap.applybackend.dto.api.CreateSubmissionResponseDto;
 import gov.cabinetoffice.gap.applybackend.dto.api.GetNavigationParamsDto;
 import gov.cabinetoffice.gap.applybackend.enums.GrantApplicationStatus;
+import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionStatus;
 import gov.cabinetoffice.gap.applybackend.enums.SubmissionSectionStatus;
 import gov.cabinetoffice.gap.applybackend.enums.SubmissionStatus;
 import gov.cabinetoffice.gap.applybackend.exception.ForbiddenException;
@@ -1372,6 +1373,7 @@ class SubmissionServiceTest {
             final GrantMandatoryQuestions grantMandatoryQuestions = GrantMandatoryQuestions.builder()
                     .id(UUID.randomUUID())
                     .gapId(gapId)
+                    .status(GrantMandatoryQuestionStatus.IN_PROGRESS)
                     .build();
 
             submission.setScheme(scheme);
@@ -1388,6 +1390,9 @@ class SubmissionServiceTest {
 
             assertThat(grantMandatoryQuestions.getGapId()).isEqualTo(gapId);
             assertThat(capturedSubmission.getGapId()).isEqualTo(gapId);
+            // Safety net: submitting completes a still-in-progress per-submission mandatory question so it is not hidden
+            // from the admin due-diligence / Spotlight exports.
+            assertThat(grantMandatoryQuestions.getStatus()).isEqualTo(GrantMandatoryQuestionStatus.COMPLETED);
         }
 
         @Test
@@ -1437,10 +1442,12 @@ class SubmissionServiceTest {
                     .version(2)
                     .build();
 
-            // A lazily-healed per-submission mandatory question exists but has never been completed, so its gapId is null.
+            // A lazily-healed per-submission mandatory question exists but has never been completed, so its gapId is null
+            // and its status is still IN_PROGRESS.
             final GrantMandatoryQuestions grantMandatoryQuestions = GrantMandatoryQuestions.builder()
                     .id(UUID.randomUUID())
                     .gapId(null)
+                    .status(GrantMandatoryQuestionStatus.IN_PROGRESS)
                     .build();
 
             submission.setScheme(scheme);
@@ -1461,6 +1468,9 @@ class SubmissionServiceTest {
             verify(grantMandatoryQuestionRepository).save(mandatoryQuestionCaptor.capture());
             assertThat(mandatoryQuestionCaptor.getValue().getGapId())
                     .isEqualTo(capturedSubmission.getGapId());
+            // Safety net also completes the previously in-progress mandatory question.
+            assertThat(mandatoryQuestionCaptor.getValue().getStatus())
+                    .isEqualTo(GrantMandatoryQuestionStatus.COMPLETED);
         }
     }
 
@@ -1650,6 +1660,121 @@ class SubmissionServiceTest {
                     () -> serviceUnderTest.handleSectionReview(userId, SUBMISSION_ID, "FUNDING_DETAILS", true));
 
             verify(submissionRepository, never()).save(any());
+        }
+
+        @Test
+        void handleSectionReview_completesMandatoryQuestionAndMintsGapId_whenBothMqSectionsComplete() {
+            final Submission submission = buildSubmissionWithMandatoryQuestionSections(
+                    SubmissionSectionStatus.COMPLETED, SubmissionSectionStatus.IN_PROGRESS);
+            final GrantMandatoryQuestions mandatoryQuestion = GrantMandatoryQuestions.builder()
+                    .id(UUID.randomUUID())
+                    .status(GrantMandatoryQuestionStatus.IN_PROGRESS)
+                    .gapId(null)
+                    .build();
+            final ArgumentCaptor<GrantMandatoryQuestions> mandatoryQuestionCaptor =
+                    ArgumentCaptor.forClass(GrantMandatoryQuestions.class);
+
+            doReturn(submission).when(serviceUnderTest).getSubmissionFromDatabaseBySubmissionId(userId, SUBMISSION_ID);
+            when(submissionRepository.save(submission)).thenReturn(submission);
+            when(grantMandatoryQuestionRepository.findBySubmissionId(SUBMISSION_ID)).thenReturn(Optional.of(mandatoryQuestion));
+            when(grantMandatoryQuestionRepository.count()).thenReturn(11L);
+
+            serviceUnderTest.handleSectionReview(userId, SUBMISSION_ID, "FUNDING_DETAILS", true);
+
+            verify(grantMandatoryQuestionRepository).save(mandatoryQuestionCaptor.capture());
+            final GrantMandatoryQuestions saved = mandatoryQuestionCaptor.getValue();
+            assertThat(saved.getStatus()).isEqualTo(GrantMandatoryQuestionStatus.COMPLETED);
+            assertThat(saved.getGapId()).isNotBlank();
+            assertThat(saved.getGapId()).startsWith("GAP-LOCAL-");
+        }
+
+        @Test
+        void handleSectionReview_leavesAlreadyCompletedMandatoryQuestionUntouched_preservingSingleAppGapId() {
+            final Submission submission = buildSubmissionWithMandatoryQuestionSections(
+                    SubmissionSectionStatus.COMPLETED, SubmissionSectionStatus.IN_PROGRESS);
+            final GrantMandatoryQuestions mandatoryQuestion = GrantMandatoryQuestions.builder()
+                    .id(UUID.randomUUID())
+                    .status(GrantMandatoryQuestionStatus.COMPLETED)
+                    .gapId("GAP-LL-existing-1")
+                    .build();
+
+            doReturn(submission).when(serviceUnderTest).getSubmissionFromDatabaseBySubmissionId(userId, SUBMISSION_ID);
+            when(submissionRepository.save(submission)).thenReturn(submission);
+            when(grantMandatoryQuestionRepository.findBySubmissionId(SUBMISSION_ID)).thenReturn(Optional.of(mandatoryQuestion));
+
+            serviceUnderTest.handleSectionReview(userId, SUBMISSION_ID, "FUNDING_DETAILS", true);
+
+            // An already-completed (single-application) mandatory question is never re-saved or re-minted.
+            verify(grantMandatoryQuestionRepository, never()).save(any());
+            assertThat(mandatoryQuestion.getGapId()).isEqualTo("GAP-LL-existing-1");
+        }
+
+        @Test
+        void handleSectionReview_doesNotCompleteMandatoryQuestion_whenOnlyOneMqSectionComplete() {
+            final Submission submission = buildSubmissionWithMandatoryQuestionSections(
+                    SubmissionSectionStatus.IN_PROGRESS, SubmissionSectionStatus.IN_PROGRESS);
+
+            doReturn(submission).when(serviceUnderTest).getSubmissionFromDatabaseBySubmissionId(userId, SUBMISSION_ID);
+            when(submissionRepository.save(submission)).thenReturn(submission);
+
+            // Only FUNDING_DETAILS is being completed; ORGANISATION_DETAILS is still in progress.
+            serviceUnderTest.handleSectionReview(userId, SUBMISSION_ID, "FUNDING_DETAILS", true);
+
+            verify(grantMandatoryQuestionRepository, never()).save(any());
+        }
+
+        @Test
+        void handleSectionReview_doesNotTouchMandatoryQuestion_whenSectionReopened() {
+            final Submission submission = buildSubmissionWithMandatoryQuestionSections(
+                    SubmissionSectionStatus.COMPLETED, SubmissionSectionStatus.COMPLETED);
+
+            doReturn(submission).when(serviceUnderTest).getSubmissionFromDatabaseBySubmissionId(userId, SUBMISSION_ID);
+            when(submissionRepository.save(submission)).thenReturn(submission);
+
+            // Re-opening a section is a one-way no-op for the mandatory question (no flip back to IN_PROGRESS).
+            serviceUnderTest.handleSectionReview(userId, SUBMISSION_ID, "FUNDING_DETAILS", false);
+
+            verify(grantMandatoryQuestionRepository, never()).save(any());
+        }
+
+        private Submission buildSubmissionWithMandatoryQuestionSections(
+                final SubmissionSectionStatus organisationStatus,
+                final SubmissionSectionStatus fundingStatus) {
+            final SubmissionQuestionValidation mandatory = SubmissionQuestionValidation.builder()
+                    .mandatory(true)
+                    .build();
+            final SubmissionSection organisationSection = SubmissionSection.builder()
+                    .sectionId("ORGANISATION_DETAILS")
+                    .sectionStatus(organisationStatus)
+                    .questions(List.of(SubmissionQuestion.builder()
+                            .questionId("APPLICANT_ORG_NAME")
+                            .response(orgName)
+                            .validation(mandatory)
+                            .build()))
+                    .build();
+            final SubmissionSection fundingSection = SubmissionSection.builder()
+                    .sectionId("FUNDING_DETAILS")
+                    .sectionStatus(fundingStatus)
+                    .questions(List.of(
+                            SubmissionQuestion.builder()
+                                    .questionId("APPLICANT_AMOUNT")
+                                    .response(amount)
+                                    .validation(mandatory)
+                                    .build(),
+                            SubmissionQuestion.builder()
+                                    .questionId("BENEFITIARY_LOCATION")
+                                    .multiResponse(beneficiaryLocation)
+                                    .validation(mandatory)
+                                    .build()))
+                    .build();
+            return Submission.builder()
+                    .id(SUBMISSION_ID)
+                    .applicant(GrantApplicant.builder().id(1).userId(userId).build())
+                    .scheme(GrantScheme.builder().version(2).build())
+                    .definition(SubmissionDefinition.builder()
+                            .sections(new ArrayList<>(List.of(organisationSection, fundingSection)))
+                            .build())
+                    .build();
         }
     }
 

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/SubmissionServiceTest.java
@@ -12,6 +12,7 @@ import gov.cabinetoffice.gap.applybackend.enums.SubmissionSectionStatus;
 import gov.cabinetoffice.gap.applybackend.enums.SubmissionStatus;
 import gov.cabinetoffice.gap.applybackend.exception.ForbiddenException;
 import gov.cabinetoffice.gap.applybackend.exception.NotFoundException;
+import gov.cabinetoffice.gap.applybackend.exception.SectionNotReadyException;
 import gov.cabinetoffice.gap.applybackend.exception.SubmissionAlreadySubmittedException;
 import gov.cabinetoffice.gap.applybackend.exception.SubmissionNotReadyException;
 import gov.cabinetoffice.gap.applybackend.model.*;
@@ -1421,6 +1422,46 @@ class SubmissionServiceTest {
 
             assertThat(capturedSubmission.getGapId()).isEqualTo(gapId);
         }
+
+        @Test
+        void submit_MintsGapIdAndWritesItBackToMandatoryQuestion_WhenMandatoryQuestionHasNoGapId() {
+            final String emailAddress = "test@email.com";
+            final ArgumentCaptor<Submission> submissionCaptor = ArgumentCaptor.forClass(Submission.class);
+            final ArgumentCaptor<GrantMandatoryQuestions> mandatoryQuestionCaptor =
+                    ArgumentCaptor.forClass(GrantMandatoryQuestions.class);
+            final GrantApplicant grantApplicant = GrantApplicant.builder()
+                    .userId(userId)
+                    .id(1)
+                    .build();
+            final GrantScheme scheme = GrantScheme.builder()
+                    .version(2)
+                    .build();
+
+            // A lazily-healed per-submission mandatory question exists but has never been completed, so its gapId is null.
+            final GrantMandatoryQuestions grantMandatoryQuestions = GrantMandatoryQuestions.builder()
+                    .id(UUID.randomUUID())
+                    .gapId(null)
+                    .build();
+
+            submission.setScheme(scheme);
+
+            when(grantMandatoryQuestionRepository.findBySubmissionId(submission.getId()))
+                    .thenReturn(Optional.of(grantMandatoryQuestions));
+            when(diligenceCheckRepository.countDistinctByApplicationNumberContains(any())).thenReturn(1L);
+            doReturn(true).when(serviceUnderTest).isSubmissionReadyToBeSubmitted(userId, SUBMISSION_ID);
+
+            serviceUnderTest.submit(submission, grantApplicant, emailAddress);
+
+            verify(submissionRepository).save(submissionCaptor.capture());
+            final Submission capturedSubmission = submissionCaptor.getValue();
+
+            assertThat(capturedSubmission.getGapId()).isNotBlank();
+            assertThat(capturedSubmission.getGapId()).startsWith("GAP-LOCAL-");
+
+            verify(grantMandatoryQuestionRepository).save(mandatoryQuestionCaptor.capture());
+            assertThat(mandatoryQuestionCaptor.getValue().getGapId())
+                    .isEqualTo(capturedSubmission.getGapId());
+        }
     }
 
     @Nested
@@ -1574,6 +1615,41 @@ class SubmissionServiceTest {
             verify(submissionRepository).save(submissionCaptor.capture());
             final Submission capturedSubmission = submissionCaptor.getValue();
             assertTrue(capturedSubmission.getMandatorySectionsCompleted());
+        }
+
+        @Test
+        void handleSectionReview_throwsAndDoesNotComplete_WhenMandatoryQuestionUnanswered() {
+            final SubmissionQuestionValidation mandatory = SubmissionQuestionValidation.builder()
+                    .mandatory(true)
+                    .build();
+            final SubmissionQuestion unansweredAmount = SubmissionQuestion.builder()
+                    .questionId("APPLICANT_AMOUNT")
+                    .validation(mandatory)
+                    .build();
+            final SubmissionQuestion unansweredLocation = SubmissionQuestion.builder()
+                    .questionId("BENEFITIARY_LOCATION")
+                    .validation(mandatory)
+                    .build();
+            final Submission submissionWithEmptyFunding = Submission.builder()
+                    .id(SUBMISSION_ID)
+                    .definition(SubmissionDefinition.builder()
+                            .sections(List.of(
+                                    SubmissionSection.builder()
+                                            .sectionId("FUNDING_DETAILS")
+                                            .sectionStatus(SubmissionSectionStatus.IN_PROGRESS)
+                                            .questions(List.of(unansweredAmount, unansweredLocation))
+                                            .build()
+                            ))
+                            .build())
+                    .build();
+
+            doReturn(submissionWithEmptyFunding).when(serviceUnderTest)
+                    .getSubmissionFromDatabaseBySubmissionId(userId, SUBMISSION_ID);
+
+            assertThrows(SectionNotReadyException.class,
+                    () -> serviceUnderTest.handleSectionReview(userId, SUBMISSION_ID, "FUNDING_DETAILS", true));
+
+            verify(submissionRepository, never()).save(any());
         }
     }
 

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsControllerTest.java
@@ -163,6 +163,28 @@ class GrantMandatoryQuestionsControllerTest {
     }
 
     @Test
+    void ensureMandatoryQuestionForSubmission_DelegatesToService_AndReturnsDto() {
+        final UUID submissionId = UUID.randomUUID();
+        final GrantMandatoryQuestions mandatoryQuestions = GrantMandatoryQuestions.builder()
+                .id(MANDATORY_QUESTION_ID)
+                .build();
+        final GetGrantMandatoryQuestionDto dto = GetGrantMandatoryQuestionDto.builder()
+                .id(MANDATORY_QUESTION_ID)
+                .build();
+
+        when(grantMandatoryQuestionService.ensureMandatoryQuestionForSubmission(submissionId, applicantUserId))
+                .thenReturn(mandatoryQuestions);
+        when(grantMandatoryQuestionMapper.mapGrantMandatoryQuestionToGetGrantMandatoryQuestionDTO(mandatoryQuestions))
+                .thenReturn(dto);
+
+        final ResponseEntity<GetGrantMandatoryQuestionDto> methodResponse = controllerUnderTest.ensureMandatoryQuestionForSubmission(submissionId);
+
+        verify(grantMandatoryQuestionService).ensureMandatoryQuestionForSubmission(submissionId, applicantUserId);
+        assertThat(methodResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(methodResponse.getBody()).isEqualTo(dto);
+    }
+
+    @Test
     void createMandatoryQuestion_AdvertIsNotPublished_CreatesMandatoryQuestionEntry_AndReturnsItsID() {
 
         final GrantMandatoryQuestions emptyMandatoryQuestions = GrantMandatoryQuestions.builder()

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsControllerTest.java
@@ -141,6 +141,28 @@ class GrantMandatoryQuestionsControllerTest {
     }
 
     @Test
+    void createMandatoryQuestionForNewSubmission_DelegatesToService_AndReturnsDto() {
+        final UUID submissionId = UUID.randomUUID();
+        final GrantMandatoryQuestions mandatoryQuestions = GrantMandatoryQuestions.builder()
+                .id(MANDATORY_QUESTION_ID)
+                .build();
+        final GetGrantMandatoryQuestionDto dto = GetGrantMandatoryQuestionDto.builder()
+                .id(MANDATORY_QUESTION_ID)
+                .build();
+
+        when(grantMandatoryQuestionService.createMandatoryQuestionForNewSubmission(submissionId, applicantUserId))
+                .thenReturn(mandatoryQuestions);
+        when(grantMandatoryQuestionMapper.mapGrantMandatoryQuestionToGetGrantMandatoryQuestionDTO(mandatoryQuestions))
+                .thenReturn(dto);
+
+        final ResponseEntity<GetGrantMandatoryQuestionDto> methodResponse = controllerUnderTest.createMandatoryQuestionForNewSubmission(submissionId);
+
+        verify(grantMandatoryQuestionService).createMandatoryQuestionForNewSubmission(submissionId, applicantUserId);
+        assertThat(methodResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(methodResponse.getBody()).isEqualTo(dto);
+    }
+
+    @Test
     void createMandatoryQuestion_AdvertIsNotPublished_CreatesMandatoryQuestionEntry_AndReturnsItsID() {
 
         final GrantMandatoryQuestions emptyMandatoryQuestions = GrantMandatoryQuestions.builder()

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/GrantMandatoryQuestionsControllerTest.java
@@ -141,28 +141,6 @@ class GrantMandatoryQuestionsControllerTest {
     }
 
     @Test
-    void createMandatoryQuestionForNewSubmission_DelegatesToService_AndReturnsDto() {
-        final UUID submissionId = UUID.randomUUID();
-        final GrantMandatoryQuestions mandatoryQuestions = GrantMandatoryQuestions.builder()
-                .id(MANDATORY_QUESTION_ID)
-                .build();
-        final GetGrantMandatoryQuestionDto dto = GetGrantMandatoryQuestionDto.builder()
-                .id(MANDATORY_QUESTION_ID)
-                .build();
-
-        when(grantMandatoryQuestionService.createMandatoryQuestionForNewSubmission(submissionId, applicantUserId))
-                .thenReturn(mandatoryQuestions);
-        when(grantMandatoryQuestionMapper.mapGrantMandatoryQuestionToGetGrantMandatoryQuestionDTO(mandatoryQuestions))
-                .thenReturn(dto);
-
-        final ResponseEntity<GetGrantMandatoryQuestionDto> methodResponse = controllerUnderTest.createMandatoryQuestionForNewSubmission(submissionId);
-
-        verify(grantMandatoryQuestionService).createMandatoryQuestionForNewSubmission(submissionId, applicantUserId);
-        assertThat(methodResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(methodResponse.getBody()).isEqualTo(dto);
-    }
-
-    @Test
     void ensureMandatoryQuestionForSubmission_DelegatesToService_AndReturnsDto() {
         final UUID submissionId = UUID.randomUUID();
         final GrantMandatoryQuestions mandatoryQuestions = GrantMandatoryQuestions.builder()

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/SubmissionControllerTest.java
@@ -602,6 +602,12 @@ class SubmissionControllerTest {
                 verify(submissionService).getSubmissionFromDatabaseBySubmissionId(APPLICANT_USER_ID, SUBMISSION_ID);
                 verify(submissionService).submit(submission, grantApplicant, emailAddress);
 
+                // Backstop: the submission is healed (so it owns its mandatory question) BEFORE it is submitted.
+                final org.mockito.InOrder inOrder = Mockito.inOrder(mandatoryQuestionService, submissionService);
+                inOrder.verify(mandatoryQuestionService)
+                        .ensureMandatoryQuestionForSubmission(submission.getId(), grantApplicant.getUserId());
+                inOrder.verify(submissionService).submit(submission, grantApplicant, emailAddress);
+
                 assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
                 assertThat(response.getBody()).isEqualTo("Submitted");
             }

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/web/controlleradvice/ControllerExceptionHandlerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/web/controlleradvice/ControllerExceptionHandlerTest.java
@@ -279,6 +279,28 @@ class ControllerExceptionHandlerTest {
     }
 
     @Test
+    void handleSectionNotReady_ReturnsExpectedResponseBody() {
+
+        final String errorMessage = "You must answer every question in this section before you can mark it as completed.";
+        final Error validationError = Error.builder()
+                .fieldName("isComplete")
+                .errorMessage(errorMessage)
+                .build();
+
+        final ErrorResponseBody expectedResponse = ErrorResponseBody.builder()
+                .errors(List.of(validationError))
+                .responseAccepted(false)
+                .message("Validation failure")
+                .build();
+
+        final SectionNotReadyException ex = new SectionNotReadyException(errorMessage);
+
+        final ErrorResponseBody methodResponse = exceptionHandlerUnderTest.handleSectionNotReady(ex);
+
+        assertThat(methodResponse).isEqualTo(expectedResponse);
+    }
+
+    @Test
     void handleAttachment_ReturnsExpectedResponseBody() {
 
         final String errorMessage = "File must be of type TXT, CSV, XLSX, DOCX";


### PR DESCRIPTION
## Description

Ticket: GAP-2795 — <paste Jira link>

Adds support for submitting multiple applications to the same scheme by giving every submission its own mandatory-questions (MQ) record. Previously a scheme used a single shared MQ record per applicant (by design, for the one-application-per-scheme model). To enable multiple applications, each submission now owns and re-confirms its own organisation and funding details, so one application can no longer affect another's funding amount or funding location.

Changes:
- Per-submission MQ (copy-on-write): `GrantMandatoryQuestionService.ensureMandatoryQuestionForSubmission` creates a submission's own MQ when none is linked, seeds organisation details from the submission's own definition (fallback: most recent MQ for the scheme, then organisation profile), and deliberately blanks funding amount, funding location and gapId so funding is captured per submission. The values are projected into that submission only (no cross-submission propagation), and a FUNDING_DETAILS section that was already COMPLETED is reopened.
- Single MQ-creation path: merged `createMandatoryQuestionForNewSubmission` into `ensureMandatoryQuestionForSubmission` and removed the now-redundant `POST /grant-mandatory-questions/new-submission/{submissionId}` endpoint and service method.
- Un-bypassable submit guard: `SubmissionController.submitApplication` calls `ensureMandatoryQuestionForSubmission` before `submissionService.submit(...)`, so a submission always owns its MQ before it is finalised.
- Section-completion validation: `handleSectionReview` throws the new `SectionNotReadyException` (handled in `ControllerExceptionHandler`) if a section is marked complete while its mandatory questions are unanswered, so FUNDING_DETAILS cannot show as "Completed" with empty funding.
- gapId on submit: `submit()` mints and persists a gapId when the linked MQ exists but has a null/blank gapId.
- MQ status lifecycle: a multi-application MQ is transitioned IN_PROGRESS -> COMPLETED (minting a gapId if absent) once ORGANISATION_DETAILS and FUNDING_DETAILS are complete. One-way and guarded so the single-application flow is unchanged.
- Keeps the submission's cached `mandatory_sections_completed` flag in sync when funding is (re)blanked.

Dependencies:
- Frontend PR in `gap-find-apply-web` must ship together (it consumes the `ensure-mandatory-question` endpoint and no longer calls the removed `/new-submission` endpoint).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

- [x] Unit Test — full `mvn test` suite green (493 tests, 0 failures; 1 pre-existing Windows-only NTFS-filename error in `postAttachment...`, unrelated to this change). Added/updated `GrantMandatoryQuestionServiceTest`, `SubmissionServiceTest`, `SubmissionControllerTest`, `GrantMandatoryQuestionsControllerTest`, `ControllerExceptionHandlerTest`.
- [ ] Integration Test (if applicable) — N/A
- [ ] End to End Test (if applicable) — manual local testing of multi-application create/edit/submit and heal-on-open scenarios

## Screenshots (if appropriate):

N/A (backend only)

# Checklist:

- [x] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.