### PR TITLE
Release/13.6 : GAP-2802 - Backfill mandatory questions

### DIFF
--- a/src/main/java/gov/cabinetoffice/gap/applybackend/model/GrantMandatoryQuestions.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/model/GrantMandatoryQuestions.java
@@ -114,4 +114,8 @@ public class GrantMandatoryQuestions extends BaseEntity {
     @Column
     private String gapId;
 
+    @Column(name = "backfill_source", nullable = false)
+    @Builder.Default
+    private boolean backfillSource = false;
+
 }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/repository/DiligenceCheckRepository.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/repository/DiligenceCheckRepository.java
@@ -4,10 +4,13 @@ import gov.cabinetoffice.gap.applybackend.model.DiligenceCheck;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface DiligenceCheckRepository extends JpaRepository<DiligenceCheck, UUID> {
     @Query("select count(distinct d) from DiligenceCheck d where d.applicationNumber like concat('%', ?1, '%')")
     long countDistinctByApplicationNumberContains(String applicationNumber);
+
+    Optional<DiligenceCheck> findBySubmissionId(UUID submissionId);
 
 }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/repository/SubmissionRepository.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/repository/SubmissionRepository.java
@@ -2,6 +2,7 @@ package gov.cabinetoffice.gap.applybackend.repository;
 
 import gov.cabinetoffice.gap.applybackend.model.Submission;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +12,15 @@ public interface SubmissionRepository extends JpaRepository<Submission, UUID> {
     List<Submission> findByApplicantId(long applicantId);
     Optional<Submission> findByApplicantIdAndApplicationId(long applicantId, Integer applicationId);
     Optional<Submission> findByIdAndApplicantUserId(UUID id, String userId);
+
+    /**
+     * Finds every submitted submission that belongs to a multi-submission application but has no
+     * mandatory question record linked to it. Used by the one-off backfill to restore the
+     * one-to-one relationship between a submission and its mandatory questions.
+     */
+    @Query("SELECT s FROM Submission s " +
+            "WHERE s.status = 'SUBMITTED' " +
+            "AND s.application.allowsMultipleSubmissions = true " +
+            "AND NOT EXISTS (SELECT 1 FROM GrantMandatoryQuestions mq WHERE mq.submission = s)")
+    List<Submission> findSubmittedMultiSubmissionWithoutMandatoryQuestions();
 }

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/backfill/MandatoryQuestionBackfillRunner.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/backfill/MandatoryQuestionBackfillRunner.java
@@ -13,8 +13,11 @@ import gov.cabinetoffice.gap.applybackend.repository.GrantMandatoryQuestionRepos
 import gov.cabinetoffice.gap.applybackend.repository.SubmissionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -56,9 +59,36 @@ public class MandatoryQuestionBackfillRunner implements ApplicationRunner {
     private final DiligenceCheckRepository diligenceCheckRepository;
     private final GrantBeneficiaryRepository grantBeneficiaryRepository;
     private final GrantMandatoryQuestionRepository grantMandatoryQuestionRepository;
+    private final ApplicationContext applicationContext;
+
+    /**
+     * When true (the default), the application shuts down once the backfill has finished. This is
+     * what you want when running the backfill as a one-off task (for example an ECS RunTask), so the
+     * container exits cleanly rather than continuing to run as a server. Set to false (in
+     * application-backfill.properties) if you would rather the application keep running afterwards,
+     * for example when running locally.
+     */
+    @Value("${backfill.exit-on-complete:true}")
+    private boolean exitOnComplete;
 
     @Override
     public void run(final ApplicationArguments args) {
+        int exitCode = 0;
+        try {
+            runBackfill();
+        } catch (final Exception e) {
+            log.error("Mandatory question backfill failed. No further records will be created.", e);
+            exitCode = 1;
+        } finally {
+            if (exitOnComplete) {
+                log.info("backfill.exit-on-complete is true; shutting the application down.");
+                final int finalExitCode = exitCode;
+                System.exit(SpringApplication.exit(applicationContext, () -> finalExitCode));
+            }
+        }
+    }
+
+    private void runBackfill() {
         final List<Submission> orphanedSubmissions = submissionRepository
                 .findSubmittedMultiSubmissionWithoutMandatoryQuestions();
 

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/backfill/MandatoryQuestionBackfillRunner.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/backfill/MandatoryQuestionBackfillRunner.java
@@ -1,0 +1,216 @@
+package gov.cabinetoffice.gap.applybackend.service.backfill;
+
+import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionFundingLocation;
+import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionOrgType;
+import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionStatus;
+import gov.cabinetoffice.gap.applybackend.model.DiligenceCheck;
+import gov.cabinetoffice.gap.applybackend.model.GrantBeneficiary;
+import gov.cabinetoffice.gap.applybackend.model.GrantMandatoryQuestions;
+import gov.cabinetoffice.gap.applybackend.model.Submission;
+import gov.cabinetoffice.gap.applybackend.repository.DiligenceCheckRepository;
+import gov.cabinetoffice.gap.applybackend.repository.GrantBeneficiaryRepository;
+import gov.cabinetoffice.gap.applybackend.repository.GrantMandatoryQuestionRepository;
+import gov.cabinetoffice.gap.applybackend.repository.SubmissionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * One-off data backfill that restores the one-to-one relationship between a submission and its
+ * mandatory questions.
+ *
+ * <p>Some historical multi-submission applications were submitted without their own mandatory
+ * question record (a previous bug shared a single record across submissions). This runner finds
+ * those submissions and creates the missing record for each one, using the data that was captured
+ * at the time of submission:
+ * <ul>
+ *     <li>funding amount and organisation details come from the {@code diligence_check} table</li>
+ *     <li>funding location comes from the {@code grant_beneficiary} table</li>
+ *     <li>organisation type comes from the submission's stored answers (the definition JSON)</li>
+ * </ul>
+ *
+ * <p>A mandatory question record is always created for every orphaned submission, even when none of
+ * that supporting data is available — in that case the record is created with empty values so the
+ * one-to-one relationship still exists. Any record created with missing data is logged as a warning.
+ *
+ * <p>This runner only executes when the application is started with the {@code backfill} Spring
+ * profile active (for example {@code --spring.profiles.active=backfill}). It does nothing in normal
+ * operation.
+ */
+@Component
+@Profile("backfill")
+@RequiredArgsConstructor
+@Slf4j
+public class MandatoryQuestionBackfillRunner implements ApplicationRunner {
+
+    private static final String APPLICANT_TYPE_QUESTION_ID = "APPLICANT_TYPE";
+
+    private final SubmissionRepository submissionRepository;
+    private final DiligenceCheckRepository diligenceCheckRepository;
+    private final GrantBeneficiaryRepository grantBeneficiaryRepository;
+    private final GrantMandatoryQuestionRepository grantMandatoryQuestionRepository;
+
+    @Override
+    public void run(final ApplicationArguments args) {
+        final List<Submission> orphanedSubmissions = submissionRepository
+                .findSubmittedMultiSubmissionWithoutMandatoryQuestions();
+
+        log.info("Mandatory question backfill starting. Found {} submitted submission(s) with no mandatory question record.",
+                orphanedSubmissions.size());
+
+        int created = 0;
+        int partial = 0;
+
+        for (final Submission submission : orphanedSubmissions) {
+            final GrantMandatoryQuestions mandatoryQuestions = buildMandatoryQuestionsForSubmission(submission);
+            grantMandatoryQuestionRepository.save(mandatoryQuestions);
+            created++;
+
+            if (isPartial(mandatoryQuestions)) {
+                partial++;
+                log.warn("Created a partial mandatory question record for submission {} (gapId {}). "
+                                + "Some data could not be found and was left empty.",
+                        submission.getId(), submission.getGapId());
+            }
+        }
+
+        log.info("Mandatory question backfill complete. Processed {}, created {}, of which {} were partial.",
+                orphanedSubmissions.size(), created, partial);
+    }
+
+    private GrantMandatoryQuestions buildMandatoryQuestionsForSubmission(final Submission submission) {
+        final GrantMandatoryQuestions mandatoryQuestions = GrantMandatoryQuestions.builder()
+                .grantScheme(submission.getScheme())
+                .submission(submission)
+                .createdBy(submission.getApplicant())
+                .gapId(submission.getGapId())
+                .status(GrantMandatoryQuestionStatus.COMPLETED)
+                .build();
+
+        applyDiligenceCheckData(submission, mandatoryQuestions);
+        applyBeneficiaryData(submission, mandatoryQuestions);
+        applyOrgType(submission, mandatoryQuestions);
+
+        return mandatoryQuestions;
+    }
+
+    /**
+     * Copies the organisation details and funding amount that were recorded against the submission
+     * in the diligence check table. Leaves the fields empty if there is no diligence check record.
+     */
+    private void applyDiligenceCheckData(final Submission submission, final GrantMandatoryQuestions mandatoryQuestions) {
+        final DiligenceCheck diligenceCheck = diligenceCheckRepository
+                .findBySubmissionId(submission.getId())
+                .orElse(null);
+
+        if (diligenceCheck == null) {
+            return;
+        }
+
+        mandatoryQuestions.setName(diligenceCheck.getOrganisationName());
+        mandatoryQuestions.setAddressLine1(diligenceCheck.getAddressStreet());
+        mandatoryQuestions.setCity(diligenceCheck.getAddressTown());
+        mandatoryQuestions.setCounty(diligenceCheck.getAddressCounty());
+        mandatoryQuestions.setPostcode(diligenceCheck.getAddressPostcode());
+        mandatoryQuestions.setCompaniesHouseNumber(diligenceCheck.getCompaniesHouseNumber());
+        mandatoryQuestions.setCharityCommissionNumber(diligenceCheck.getCharityNumber());
+        mandatoryQuestions.setFundingAmount(parseFundingAmount(diligenceCheck.getApplicationAmount(), submission));
+    }
+
+    /**
+     * Copies the funding location that was recorded against the submission in the beneficiary table.
+     * Leaves the funding location empty if there is no beneficiary record.
+     */
+    private void applyBeneficiaryData(final Submission submission, final GrantMandatoryQuestions mandatoryQuestions) {
+        final GrantBeneficiary beneficiary = grantBeneficiaryRepository
+                .findBySubmissionId(submission.getId())
+                .orElse(null);
+
+        if (beneficiary == null) {
+            return;
+        }
+
+        mandatoryQuestions.setFundingLocation(mapBeneficiaryLocations(beneficiary));
+    }
+
+    /**
+     * Reads the organisation type from the answers the applicant submitted (the definition JSON),
+     * which is the most accurate record of what they chose at submission time. Leaves it empty if
+     * the answer cannot be found.
+     */
+    private void applyOrgType(final Submission submission, final GrantMandatoryQuestions mandatoryQuestions) {
+        if (submission.getDefinition() == null || submission.getDefinition().getSections() == null) {
+            return;
+        }
+
+        submission.getDefinition().getSections().stream()
+                .filter(section -> section.getQuestions() != null)
+                .flatMap(section -> section.getQuestions().stream())
+                .filter(question -> APPLICANT_TYPE_QUESTION_ID.equals(question.getQuestionId()))
+                .map(question -> question.getResponse())
+                .filter(response -> response != null && !response.isBlank())
+                .findFirst()
+                .map(GrantMandatoryQuestionOrgType::valueOfName)
+                .ifPresent(mandatoryQuestions::setOrgType);
+    }
+
+    private BigDecimal parseFundingAmount(final String applicationAmount, final Submission submission) {
+        if (applicationAmount == null || applicationAmount.isBlank()) {
+            return null;
+        }
+
+        try {
+            return new BigDecimal(applicationAmount.trim());
+        } catch (final NumberFormatException e) {
+            log.warn("Could not parse funding amount '{}' for submission {} (gapId {}). Leaving it empty.",
+                    applicationAmount, submission.getId(), submission.getGapId());
+            return null;
+        }
+    }
+
+    private GrantMandatoryQuestionFundingLocation[] mapBeneficiaryLocations(final GrantBeneficiary beneficiary) {
+        final List<GrantMandatoryQuestionFundingLocation> locations = new ArrayList<>();
+
+        addIfTrue(locations, beneficiary.getLocationNeEng(), GrantMandatoryQuestionFundingLocation.NORTH_EAST_ENGLAND);
+        addIfTrue(locations, beneficiary.getLocationNwEng(), GrantMandatoryQuestionFundingLocation.NORTH_WEST_ENGLAND);
+        addIfTrue(locations, beneficiary.getLocationSeEng(), GrantMandatoryQuestionFundingLocation.SOUTH_EAST_ENGLAND);
+        addIfTrue(locations, beneficiary.getLocationSwEng(), GrantMandatoryQuestionFundingLocation.SOUTH_WEST_ENGLAND);
+        addIfTrue(locations, beneficiary.getLocationMidEng(), GrantMandatoryQuestionFundingLocation.MIDLANDS);
+        addIfTrue(locations, beneficiary.getLocationSco(), GrantMandatoryQuestionFundingLocation.SCOTLAND);
+        addIfTrue(locations, beneficiary.getLocationWal(), GrantMandatoryQuestionFundingLocation.WALES);
+        addIfTrue(locations, beneficiary.getLocationNir(), GrantMandatoryQuestionFundingLocation.NORTHERN_IRELAND);
+        addIfTrue(locations, beneficiary.getLocationLon(), GrantMandatoryQuestionFundingLocation.LONDON);
+        addIfTrue(locations, beneficiary.getLocationOutUk(), GrantMandatoryQuestionFundingLocation.OUTSIDE_UK);
+
+        if (locations.isEmpty()) {
+            return null;
+        }
+
+        return locations.toArray(new GrantMandatoryQuestionFundingLocation[0]);
+    }
+
+    private void addIfTrue(final List<GrantMandatoryQuestionFundingLocation> locations,
+            final Boolean flag, final GrantMandatoryQuestionFundingLocation location) {
+        if (Boolean.TRUE.equals(flag)) {
+            locations.add(location);
+        }
+    }
+
+    /**
+     * A record is "partial" if any of the key data we were trying to recover is missing. These are
+     * logged so they can be reviewed manually after the backfill has run.
+     */
+    private boolean isPartial(final GrantMandatoryQuestions mandatoryQuestions) {
+        return mandatoryQuestions.getName() == null
+                || mandatoryQuestions.getFundingAmount() == null
+                || mandatoryQuestions.getFundingLocation() == null
+                || mandatoryQuestions.getOrgType() == null;
+    }
+}

--- a/src/main/java/gov/cabinetoffice/gap/applybackend/service/backfill/MandatoryQuestionBackfillRunner.java
+++ b/src/main/java/gov/cabinetoffice/gap/applybackend/service/backfill/MandatoryQuestionBackfillRunner.java
@@ -71,6 +71,14 @@ public class MandatoryQuestionBackfillRunner implements ApplicationRunner {
     @Value("${backfill.exit-on-complete:true}")
     private boolean exitOnComplete;
 
+    /**
+     * Maximum number of submissions to process in a single run. Useful for cautious incremental
+     * execution in production — run with backfill.batch-size=1 to process one record, verify it,
+     * then re-run to process the next. Defaults to -1 (process all orphaned submissions).
+     */
+    @Value("${backfill.batch-size:-1}")
+    private int batchSize;
+
     @Override
     public void run(final ApplicationArguments args) {
         int exitCode = 0;
@@ -89,11 +97,15 @@ public class MandatoryQuestionBackfillRunner implements ApplicationRunner {
     }
 
     private void runBackfill() {
-        final List<Submission> orphanedSubmissions = submissionRepository
+        final List<Submission> allOrphaned = submissionRepository
                 .findSubmittedMultiSubmissionWithoutMandatoryQuestions();
 
-        log.info("Mandatory question backfill starting. Found {} submitted submission(s) with no mandatory question record.",
-                orphanedSubmissions.size());
+        final List<Submission> orphanedSubmissions = (batchSize > 0)
+                ? allOrphaned.subList(0, Math.min(batchSize, allOrphaned.size()))
+                : allOrphaned;
+
+        log.info("Mandatory question backfill starting. Found {} submitted submission(s) with no mandatory question record. Processing {}.",
+                allOrphaned.size(), orphanedSubmissions.size());
 
         int created = 0;
         int partial = 0;
@@ -122,6 +134,7 @@ public class MandatoryQuestionBackfillRunner implements ApplicationRunner {
                 .createdBy(submission.getApplicant())
                 .gapId(submission.getGapId())
                 .status(GrantMandatoryQuestionStatus.COMPLETED)
+                .backfillSource(true)
                 .build();
 
         applyDiligenceCheckData(submission, mandatoryQuestions);

--- a/src/main/resources/application-backfill.properties
+++ b/src/main/resources/application-backfill.properties
@@ -8,5 +8,13 @@
 #
 #     --spring.profiles.active=backfill
 #
-# The runner executes once on startup, logs a summary of what it created, and otherwise leaves the
-# application running as normal. Remove the profile to return to normal operation.
+# The runner executes once on startup and logs a summary of what it created.
+#
+# By default the application shuts down cleanly once the backfill finishes (exit code 0, or 1 if it
+# failed). This is what you want when running it as a one-off task such as an ECS RunTask, so the
+# container stops rather than continuing to run as a server.
+#
+# If you would rather the application keep running after the backfill (for example when running
+# locally so you can keep using the service), uncomment the line below:
+#
+# backfill.exit-on-complete=false

--- a/src/main/resources/application-backfill.properties
+++ b/src/main/resources/application-backfill.properties
@@ -1,0 +1,12 @@
+# Configuration for the one-off "backfill" profile.
+#
+# This profile exists solely to run MandatoryQuestionBackfillRunner, which creates the missing
+# mandatory question records for historical multi-submission applications.
+#
+# It is NOT part of normal operation. To run the backfill, start the applicant backend with this
+# profile active, for example:
+#
+#     --spring.profiles.active=backfill
+#
+# The runner executes once on startup, logs a summary of what it created, and otherwise leaves the
+# application running as normal. Remove the profile to return to normal operation.

--- a/src/main/resources/application-backfill.properties
+++ b/src/main/resources/application-backfill.properties
@@ -18,3 +18,10 @@
 # locally so you can keep using the service), uncomment the line below:
 #
 # backfill.exit-on-complete=false
+
+# To process only a limited number of records per run, set backfill.batch-size to a positive
+# integer. This is useful for cautious incremental execution in any environment (local, test, or
+# production) — run with batch-size=1, verify the result, then re-run to process the next record.
+# Defaults to -1, which processes all orphaned submissions in one run.
+#
+# backfill.batch-size=1

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/backfill/MandatoryQuestionBackfillRunnerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/backfill/MandatoryQuestionBackfillRunnerTest.java
@@ -1,0 +1,170 @@
+package gov.cabinetoffice.gap.applybackend.service.backfill;
+
+import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionFundingLocation;
+import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionOrgType;
+import gov.cabinetoffice.gap.applybackend.enums.GrantMandatoryQuestionStatus;
+import gov.cabinetoffice.gap.applybackend.model.DiligenceCheck;
+import gov.cabinetoffice.gap.applybackend.model.GrantApplicant;
+import gov.cabinetoffice.gap.applybackend.model.GrantBeneficiary;
+import gov.cabinetoffice.gap.applybackend.model.GrantMandatoryQuestions;
+import gov.cabinetoffice.gap.applybackend.model.GrantScheme;
+import gov.cabinetoffice.gap.applybackend.model.Submission;
+import gov.cabinetoffice.gap.applybackend.model.SubmissionDefinition;
+import gov.cabinetoffice.gap.applybackend.model.SubmissionQuestion;
+import gov.cabinetoffice.gap.applybackend.model.SubmissionSection;
+import gov.cabinetoffice.gap.applybackend.repository.DiligenceCheckRepository;
+import gov.cabinetoffice.gap.applybackend.repository.GrantBeneficiaryRepository;
+import gov.cabinetoffice.gap.applybackend.repository.GrantMandatoryQuestionRepository;
+import gov.cabinetoffice.gap.applybackend.repository.SubmissionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MandatoryQuestionBackfillRunnerTest {
+
+    @Mock
+    private SubmissionRepository submissionRepository;
+
+    @Mock
+    private DiligenceCheckRepository diligenceCheckRepository;
+
+    @Mock
+    private GrantBeneficiaryRepository grantBeneficiaryRepository;
+
+    @Mock
+    private GrantMandatoryQuestionRepository grantMandatoryQuestionRepository;
+
+    @InjectMocks
+    private MandatoryQuestionBackfillRunner runner;
+
+    private Submission buildSubmission(final UUID id, final String orgTypeResponse) {
+        final List<SubmissionQuestion> questions = new ArrayList<>();
+        if (orgTypeResponse != null) {
+            questions.add(SubmissionQuestion.builder()
+                    .questionId("APPLICANT_TYPE")
+                    .response(orgTypeResponse)
+                    .build());
+        }
+        final SubmissionDefinition definition = SubmissionDefinition.builder()
+                .sections(List.of(SubmissionSection.builder()
+                        .sectionId("ESSENTIAL")
+                        .questions(questions)
+                        .build()))
+                .build();
+
+        return Submission.builder()
+                .id(id)
+                .gapId("GAP-PRD-202606100918-256816-86889")
+                .scheme(GrantScheme.builder().id(1).build())
+                .applicant(GrantApplicant.builder().id(99L).build())
+                .definition(definition)
+                .build();
+    }
+
+    @Test
+    void createsFullyPopulatedRecord_WhenAllSourceDataIsAvailable() {
+        final UUID submissionId = UUID.randomUUID();
+        final Submission submission = buildSubmission(submissionId, "Limited company");
+
+        when(submissionRepository.findSubmittedMultiSubmissionWithoutMandatoryQuestions())
+                .thenReturn(List.of(submission));
+        when(diligenceCheckRepository.findBySubmissionId(submissionId))
+                .thenReturn(Optional.of(DiligenceCheck.builder()
+                        .organisationName("AND Digital")
+                        .addressStreet("215 Bothwell Street")
+                        .addressTown("Glasgow")
+                        .addressPostcode("G2 7EZ")
+                        .companiesHouseNumber("1234567")
+                        .charityNumber("22135")
+                        .applicationAmount("500")
+                        .build()));
+        when(grantBeneficiaryRepository.findBySubmissionId(submissionId))
+                .thenReturn(Optional.of(GrantBeneficiary.builder()
+                        .locationSco(true)
+                        .build()));
+
+        runner.run(null);
+
+        final ArgumentCaptor<GrantMandatoryQuestions> captor = ArgumentCaptor.forClass(GrantMandatoryQuestions.class);
+        verify(grantMandatoryQuestionRepository).save(captor.capture());
+
+        final GrantMandatoryQuestions saved = captor.getValue();
+        assertThat(saved.getSubmission()).isEqualTo(submission);
+        assertThat(saved.getGapId()).isEqualTo(submission.getGapId());
+        assertThat(saved.getStatus()).isEqualTo(GrantMandatoryQuestionStatus.COMPLETED);
+        assertThat(saved.getName()).isEqualTo("AND Digital");
+        assertThat(saved.getFundingAmount()).isEqualByComparingTo(BigDecimal.valueOf(500));
+        assertThat(saved.getFundingLocation()).containsExactly(GrantMandatoryQuestionFundingLocation.SCOTLAND);
+        assertThat(saved.getOrgType()).isEqualTo(GrantMandatoryQuestionOrgType.LIMITED_COMPANY);
+    }
+
+    @Test
+    void createsPartialRecord_WhenNoSourceDataIsAvailable() {
+        final UUID submissionId = UUID.randomUUID();
+        final Submission submission = buildSubmission(submissionId, null);
+
+        when(submissionRepository.findSubmittedMultiSubmissionWithoutMandatoryQuestions())
+                .thenReturn(List.of(submission));
+        when(diligenceCheckRepository.findBySubmissionId(submissionId)).thenReturn(Optional.empty());
+        when(grantBeneficiaryRepository.findBySubmissionId(submissionId)).thenReturn(Optional.empty());
+
+        runner.run(null);
+
+        final ArgumentCaptor<GrantMandatoryQuestions> captor = ArgumentCaptor.forClass(GrantMandatoryQuestions.class);
+        verify(grantMandatoryQuestionRepository).save(captor.capture());
+
+        final GrantMandatoryQuestions saved = captor.getValue();
+        // The record is still created so the one-to-one relationship exists, but with empty values
+        assertThat(saved.getSubmission()).isEqualTo(submission);
+        assertThat(saved.getStatus()).isEqualTo(GrantMandatoryQuestionStatus.COMPLETED);
+        assertThat(saved.getName()).isNull();
+        assertThat(saved.getFundingAmount()).isNull();
+        assertThat(saved.getFundingLocation()).isNull();
+        assertThat(saved.getOrgType()).isNull();
+    }
+
+    @Test
+    void leavesFundingAmountEmpty_WhenAmountCannotBeParsed() {
+        final UUID submissionId = UUID.randomUUID();
+        final Submission submission = buildSubmission(submissionId, "Limited company");
+
+        when(submissionRepository.findSubmittedMultiSubmissionWithoutMandatoryQuestions())
+                .thenReturn(List.of(submission));
+        when(diligenceCheckRepository.findBySubmissionId(submissionId))
+                .thenReturn(Optional.of(DiligenceCheck.builder().applicationAmount("not-a-number").build()));
+        when(grantBeneficiaryRepository.findBySubmissionId(submissionId)).thenReturn(Optional.empty());
+
+        runner.run(null);
+
+        final ArgumentCaptor<GrantMandatoryQuestions> captor = ArgumentCaptor.forClass(GrantMandatoryQuestions.class);
+        verify(grantMandatoryQuestionRepository).save(captor.capture());
+
+        assertThat(captor.getValue().getFundingAmount()).isNull();
+    }
+
+    @Test
+    void doesNothing_WhenThereAreNoOrphanedSubmissions() {
+        when(submissionRepository.findSubmittedMultiSubmissionWithoutMandatoryQuestions())
+                .thenReturn(List.of());
+
+        runner.run(null);
+
+        verify(grantMandatoryQuestionRepository, never()).save(any());
+    }
+}

--- a/src/test/java/gov/cabinetoffice/gap/applybackend/service/backfill/MandatoryQuestionBackfillRunnerTest.java
+++ b/src/test/java/gov/cabinetoffice/gap/applybackend/service/backfill/MandatoryQuestionBackfillRunnerTest.java
@@ -29,9 +29,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.test.util.ReflectionTestUtils;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -112,6 +115,7 @@ class MandatoryQuestionBackfillRunnerTest {
         assertThat(saved.getFundingAmount()).isEqualByComparingTo(BigDecimal.valueOf(500));
         assertThat(saved.getFundingLocation()).containsExactly(GrantMandatoryQuestionFundingLocation.SCOTLAND);
         assertThat(saved.getOrgType()).isEqualTo(GrantMandatoryQuestionOrgType.LIMITED_COMPANY);
+        assertThat(saved.isBackfillSource()).isTrue();
     }
 
     @Test
@@ -137,6 +141,7 @@ class MandatoryQuestionBackfillRunnerTest {
         assertThat(saved.getFundingAmount()).isNull();
         assertThat(saved.getFundingLocation()).isNull();
         assertThat(saved.getOrgType()).isNull();
+        assertThat(saved.isBackfillSource()).isTrue();
     }
 
     @Test
@@ -166,5 +171,23 @@ class MandatoryQuestionBackfillRunnerTest {
         runner.run(null);
 
         verify(grantMandatoryQuestionRepository, never()).save(any());
+    }
+
+    @Test
+    void processesBatchSizeRecordsOnly_WhenBatchSizeIsSet() {
+        final UUID id1 = UUID.randomUUID();
+        final UUID id2 = UUID.randomUUID();
+        final Submission submission1 = buildSubmission(id1, null);
+        final Submission submission2 = buildSubmission(id2, null);
+
+        when(submissionRepository.findSubmittedMultiSubmissionWithoutMandatoryQuestions())
+                .thenReturn(List.of(submission1, submission2));
+        when(diligenceCheckRepository.findBySubmissionId(any())).thenReturn(Optional.empty());
+        when(grantBeneficiaryRepository.findBySubmissionId(any())).thenReturn(Optional.empty());
+
+        ReflectionTestUtils.setField(runner, "batchSize", 1);
+        runner.run(null);
+
+        verify(grantMandatoryQuestionRepository, times(1)).save(any());
     }
 }


### PR DESCRIPTION
How to use it

Run the seed against your local gapapply DB
Start the backend with `--spring.profiles.active=local,backfill`
Expect the log: Processed 3, created 3, of which 2 were partial.

----

To run the backfill task on AWS:

Go to ECS > Clusters > qa-ecs-cluster
Click the Tasks tab
Click Run new task
Configure:
-    Family: qa-applicant-api-app-task
-    Revision: latest (82)
-    Launch type: Fargate

Expand Container overrides and for the gap_applicant_api container add these environment variables:
-    SPRING_PROFILES_ACTIVE = qa,backfill
-    BACKFILL_BATCH_SIZE = 1

Expand Networking and match the settings from the previous successful run:

-    Same VPC and private subnets
-    Same security group as qa-gap-applicant-api-service
-    Click Run task

Then go to CloudWatch > Log groups > find the gap_applicant_api log group and watch the logs to confirm it ran successfully. You should see a line like: